### PR TITLE
feat(logfile): add persistent logfile for N+1 findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ AndOne.configure do |config|
   # Custom backtrace cleaner
   config.backtrace_cleaner = Rails.backtrace_cleaner
 
+  # Log all unique findings to a file (default: "log/and_one.log", nil to disable)
+  config.logfile = "log/and_one.log"
+
+  # Logfile format: :text or :json (default: :text)
+  config.logfile_format = :text
+
   # Custom callback for integrations (logging services, etc.)
   config.notifications_callback = ->(detections, message) {
     # detections is an array of AndOne::Detection objects

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -16,7 +16,8 @@ module AndOne
                   :allow_stack_paths, :ignore_queries, :ignore_callers,
                   :min_n_queries, :notifications_callback,
                   :ignore_file_path, :json_logging, :env_thresholds,
-                  :dev_toast, :dev_toast_position
+                  :dev_toast, :dev_toast_position,
+                  :logfile, :logfile_format
 
     def configure
       yield self
@@ -88,6 +89,17 @@ module AndOne
     def aggregate
       @singleton_mutex.synchronize do
         @aggregate ||= Aggregate.new
+      end
+    end
+
+    def logfile_writer
+      return nil unless logfile
+
+      @singleton_mutex.synchronize do
+        @logfile_writer ||= LogfileWriter.new(
+          path: logfile,
+          format: logfile_format || :text
+        )
       end
     end
 
@@ -163,6 +175,9 @@ module AndOne
       # Record to aggregate and only report NEW unique detections
       detections = detections.select { |d| aggregate.record(d) }
       return if detections.empty?
+
+      # Buffer detections for logfile output (written on process exit)
+      logfile_writer&.record(detections)
 
       cleaner = backtrace_cleaner || default_backtrace_cleaner
 
@@ -267,6 +282,7 @@ require_relative "and_one/json_formatter"
 require_relative "and_one/association_resolver"
 require_relative "and_one/ignore_file"
 require_relative "and_one/aggregate"
+require_relative "and_one/logfile_writer"
 require_relative "and_one/matchers"
 require_relative "and_one/scan_helper"
 require_relative "and_one/dev_ui"

--- a/lib/and_one/logfile_writer.rb
+++ b/lib/and_one/logfile_writer.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+
+module AndOne
+  # Buffers N+1 detections in memory (deduplicated by fingerprint) and writes
+  # them to a log file on process exit.  Handles parallel workers (forked test
+  # processes, Puma cluster, etc.) by using file-level locking so all workers
+  # safely append.  Truncation of stale data is handled at boot in the railtie,
+  # before workers fork.
+  class LogfileWriter
+    # Clear stale findings from a previous boot.  Called once in the railtie
+    # before workers fork so every worker starts with a clean file.
+    def self.truncate!(path)
+      File.truncate(path, 0) if path && File.exist?(path)
+    end
+
+    def initialize(path:, format: :text)
+      @path = path
+      @format = format
+      @mutex = Mutex.new
+      @entries = {}
+    end
+
+    # Accept an array of Detection objects; deduplicate by fingerprint.
+    def record(detections)
+      @mutex.synchronize do
+        detections.each do |d|
+          @entries[d.fingerprint] ||= d
+        end
+      end
+    end
+
+    # Format all buffered entries and write to the log file with locking.
+    def flush!
+      entries = @mutex.synchronize do
+        snapshot = @entries.values
+        @entries = {}
+        snapshot
+      end
+      return if entries.empty?
+
+      output = format_entries(entries)
+      FileUtils.mkdir_p(File.dirname(@path))
+
+      File.open(@path, File::RDWR | File::CREAT, 0o644) do |f|
+        f.flock(File::LOCK_EX)
+        f.seek(0, IO::SEEK_END)
+        f.write("\n") if f.size.positive?
+        f.write(output)
+        f.flock(File::LOCK_UN)
+      end
+    end
+
+    private
+
+    def format_entries(entries)
+      case @format
+      when :json
+        format_json(entries)
+      else
+        format_text(entries)
+      end
+    end
+
+    def format_text(entries)
+      formatter = Formatter.new
+      output = formatter.format(entries)
+      output.gsub(/\e\[\d+(?:;\d+)*m/, "")
+    end
+
+    def format_json(entries)
+      json_formatter = JsonFormatter.new
+      hashes = json_formatter.format_hashes(entries)
+      hashes.map { |h| JSON.generate(h) }.join("\n")
+    end
+  end
+end

--- a/lib/and_one/railtie.rb
+++ b/lib/and_one/railtie.rb
@@ -7,6 +7,18 @@ module AndOne
       if Rails.env.development? || Rails.env.test?
         AndOne.enabled = true
 
+        # Default logfile for collecting all findings
+        AndOne.logfile = "log/and_one.log" if AndOne.logfile.nil?
+
+        # Truncate stale findings from previous boot before workers fork
+        LogfileWriter.truncate!(AndOne.logfile)
+
+        at_exit do
+          AndOne.logfile_writer&.flush!
+        rescue StandardError
+          # Swallow errors during shutdown to avoid confusing output
+        end
+
         # In test, raise by default so N+1s fail the test suite
         AndOne.raise_on_detect = true if Rails.env.test?
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,9 +70,12 @@ module AndOneTestHelper
     AndOne.env_thresholds = nil
     AndOne.dev_toast = false
     AndOne.dev_toast_position = nil
+    AndOne.logfile = nil
+    AndOne.logfile_format = nil
     AndOne.ignore_file_path = nil
     AndOne.reload_ignore_file!
     AndOne.instance_variable_set(:@aggregate, nil)
+    AndOne.instance_variable_set(:@logfile_writer, nil)
 
     # Clear any leftover thread state
     Thread.current[:and_one_detector] = nil

--- a/test/test_logfile_writer.rb
+++ b/test/test_logfile_writer.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+require "json"
+
+class TestLogfileWriter < Minitest::Test
+  include AndOneTestHelper
+
+  def setup
+    super
+    seed_data!
+    @tmpdir = Dir.mktmpdir("and_one_test")
+    @logfile = File.join(@tmpdir, "and_one.log")
+  end
+
+  def teardown
+    super
+    Comment.delete_all
+    Post.delete_all
+    Author.delete_all
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_flush_with_no_entries_is_noop
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    writer.flush!
+
+    refute File.exist?(@logfile)
+  end
+
+  def test_buffers_and_deduplicates_by_fingerprint
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :json)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    # Record the same detections twice
+    writer.record(detections)
+    writer.record(detections)
+    writer.flush!
+
+    content = File.read(@logfile)
+    lines = content.strip.split("\n")
+    # Should only have one line per unique fingerprint despite recording twice
+    fingerprints = lines.map { |l| JSON.parse(l)["fingerprint"] }
+    assert_equal fingerprints.uniq, fingerprints
+  end
+
+  def test_text_format_has_no_ansi_codes
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    writer.record(detections)
+    writer.flush!
+
+    content = File.read(@logfile)
+    refute_match(/\e\[\d+m/, content, "Logfile should not contain ANSI color codes")
+    assert_includes content, "N+1"
+  end
+
+  def test_json_format_produces_valid_jsonl
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :json)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    writer.record(detections)
+    writer.flush!
+
+    content = File.read(@logfile)
+    lines = content.strip.split("\n")
+    assert lines.size >= 1
+
+    lines.each do |line|
+      parsed = JSON.parse(line)
+      assert_equal "n_plus_one_detected", parsed["event"]
+      assert parsed.key?("fingerprint")
+      assert parsed.key?("table")
+    end
+  end
+
+  def test_truncate_clears_stale_file
+    File.write(@logfile, "stale data\n")
+
+    AndOne::LogfileWriter.truncate!(@logfile)
+
+    assert_equal 0, File.size(@logfile)
+  end
+
+  def test_truncate_is_noop_when_file_missing
+    AndOne::LogfileWriter.truncate!(@logfile)
+
+    refute File.exist?(@logfile)
+  end
+
+  def test_truncate_is_noop_when_path_nil
+    AndOne::LogfileWriter.truncate!(nil)
+  end
+
+  def test_appends_to_existing_file
+    # Pre-existing content should be preserved (truncation is handled at boot
+    # in the railtie, not by the writer)
+    File.write(@logfile, "existing data\n")
+
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    writer.record(detections)
+    writer.flush!
+
+    content = File.read(@logfile)
+    assert_includes content, "existing data"
+    assert_includes content, "N+1"
+  end
+
+  def test_parallel_workers_both_append
+    # Simulate two parallel workers flushing to the same file
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    writer2 = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+
+    detections_comments = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    detections_authors = capture_detections do
+      Post.all.each(&:author)
+    end
+
+    writer.record(detections_comments)
+    writer.flush!
+
+    first_content = File.read(@logfile)
+
+    writer2.record(detections_authors)
+    writer2.flush!
+
+    final_content = File.read(@logfile)
+    # Both workers' findings should be present
+    assert final_content.length > first_content.length
+    assert_includes final_content, "comments"
+    assert_includes final_content, "authors"
+  end
+
+  def test_file_locking_does_not_deadlock
+    writer = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    writer.record(detections)
+
+    # Flush twice in sequence to verify no deadlock
+    writer.flush!
+    # Second flush has no new entries (already flushed), but should not deadlock
+    writer2 = AndOne::LogfileWriter.new(path: @logfile, format: :text)
+    writer2.record(detections)
+    writer2.flush!
+
+    assert File.exist?(@logfile)
+  end
+
+  def test_creates_intermediate_directories
+    nested_path = File.join(@tmpdir, "sub", "dir", "and_one.log")
+    writer = AndOne::LogfileWriter.new(path: nested_path, format: :text)
+    detections = capture_detections do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    writer.record(detections)
+    writer.flush!
+
+    assert File.exist?(nested_path)
+  end
+
+  def test_integration_with_and_one_scan
+    AndOne.logfile = @logfile
+    AndOne.logfile_format = :text
+
+    AndOne.scan do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    AndOne.logfile_writer.flush!
+
+    content = File.read(@logfile)
+    assert_includes content, "N+1"
+    assert_includes content, "comments"
+  end
+
+  def test_integration_json_format
+    AndOne.logfile = @logfile
+    AndOne.logfile_format = :json
+
+    AndOne.scan do
+      Post.all.each { |post| post.comments.to_a }
+    end
+
+    AndOne.logfile_writer.flush!
+
+    content = File.read(@logfile)
+    lines = content.strip.split("\n")
+    lines.each do |line|
+      parsed = JSON.parse(line)
+      assert_equal "n_plus_one_detected", parsed["event"]
+    end
+  end
+
+  private
+
+  def capture_detections(&)
+    detections = []
+    original_callback = AndOne.notifications_callback
+    AndOne.notifications_callback = ->(dets, _msg) { detections.concat(dets) }
+
+    AndOne.scan(&)
+
+    AndOne.notifications_callback = original_callback
+    # Reset aggregate so subsequent scans report again
+    AndOne.instance_variable_set(:@aggregate, nil)
+    detections
+  end
+end


### PR DESCRIPTION
Developers need a way to review all detected N+1 queries across a full test suite or dev session without scrolling through terminal output. This adds a logfile writer that buffers detections in memory, deduplicates by fingerprint, and flushes to disk on process exit. File-level locking ensures safe writes from parallel workers, and stale files from previous runs are automatically truncated. Supports both plain text and JSONL output formats.