### PR TITLE
Persist shared findings and fix N+1 enforcement, scan cleanup, and SQL normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Fixed
+
+- Enforce `raise_on_detect` for every violating scan, independently of first-occurrence reporting and aggregate history (#2).
+- Release owned scans on exceptions and nonlocal exits; preserve outer scans and nested pause state (#3).
+- Tokenize SQL before fingerprint normalization, fixing PostgreSQL bind placeholders and comment characters inside quoted text (#4). Preserve quoted identifiers and structural distinctions.
+
+### Changed
+
+- **Fingerprint migration:** normalization version 2 can change detection IDs. Reset stale aggregate data and regenerate affected `fingerprint:` ignore rules. See [SQL fingerprints](docs/sql-fingerprints.md) for details and dialect limitations.
+
 ## [0.4.0] - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-05
+
+### Fixed
+
+- **Toast now respects ignore rules** — Previously, the dev toast showed all detected N+1s including ones filtered by `.and_one_ignore` or `ignore_callers`. The toast, dashboard, and log output now all show the same filtered set of detections. This also applies to the return value of `AndOne.scan { }` and `AndOne.finish`.
+
+### Changed
+
+- **Disk-based aggregate storage** — The aggregate now stores detections as JSON on disk (`tmp/and_one/` in Rails apps) instead of in-process memory. This means all Puma workers in a multi-process deployment share the same dashboard data. The aggregate is automatically reset on server boot. Configure a custom path with `AndOne.aggregate_path`.
+
+### Added
+
+- `AndOne.aggregate_path` configuration option for custom aggregate storage location
+- `Detection` now supports construction from raw caller strings (for deserialization from disk)
+
 ## [0.3.1] - 2026-03-05
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    and_one (0.3.1)
+    and_one (0.4.0)
       activerecord (>= 7.0)
       activesupport (>= 7.0)
       railties (>= 7.0)
@@ -288,7 +288,7 @@ CHECKSUMS
   activestorage (8.1.2) sha256=8a63a48c3999caeee26a59441f813f94681fc35cc41aba7ce1f836add04fba76
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
   addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
-  and_one (0.3.1)
+  and_one (0.4.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7

--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ AndOne.scan do
 end
 ```
 
+Block scans release their own detector on every exit, including exceptions, `return`, `break`, and `throw`. Only normal completion analyzes and reports findings. Nested scans pass through to the block without taking ownership of the outer scan. Nested pause blocks restore the previous pause state.
+
+For manual `AndOne.scan` / `AndOne.finish` pairs, the caller must invoke `finish` when done (including on exceptional paths, typically via `ensure`). `finish` releases the detector even if analysis or reporting raises; calling it with no active scan returns `[]`. Prefer the block API when application errors should bypass reporting.
+
 ## How It Works
 
 1. **Subscribe** to `sql.active_record` notifications (built into Rails)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AndOne stays completely invisible until it detects an N+1 query — then it tell
 - **Auto-raises in test** — N+1s fail your test suite by default
 - **Background job support** — ActiveJob (`around_perform`) and Sidekiq server middleware, with double-scan protection
 - **Ignore file** — `.and_one_ignore` with `gem:`, `path:`, `query:`, and `fingerprint:` rules
-- **Automatic deduplication** — each unique N+1 is reported once per server session with occurrence counts
+- **Automatic deduplication** — each unique N+1 is reported once per server session with occurrence counts, shared across all Puma workers via disk-based storage
 - **Test matchers** — Minitest (`assert_no_n_plus_one`) and RSpec (`expect { }.not_to cause_n_plus_one`)
 - **Dev toast notifications** — in-page toast on every page that triggers an N+1, with a link to the dashboard
 - **Dev UI dashboard** — browse `/__and_one` in development for a live N+1 overview
@@ -240,6 +240,9 @@ AndOne.configure do |config|
   # Toast position (default: :top_right)
   # Options: :top_right, :top_left, :bottom_right, :bottom_left
   config.dev_toast_position = :top_right
+
+  # Aggregate storage path (default: Rails.root/tmp/and_one)
+  config.aggregate_path = Rails.root.join("tmp", "and_one").to_s
 
   # Path to ignore file (default: Rails.root/.and_one_ignore)
   config.ignore_file_path = Rails.root.join(".and_one_ignore").to_s

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ AndOne.aggregate.size       # number of unique patterns
 AndOne.aggregate.reset!     # clear and start fresh
 ```
 
+SQL normalization version 2 can change detection fingerprints. When upgrading, reset stale aggregate data and regenerate affected `fingerprint:` ignore entries. See [SQL fingerprints](docs/sql-fingerprints.md) for supported syntax, dialect limitations, and migration steps.
+
 ## Development UI
 
 ### In-page toast notifications

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ This is especially useful for **N+1s coming from gems** where you can't add `.in
 
 In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique pattern is reported only once per server session. Subsequent occurrences are silently counted.
 
+Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan or matcher.
+
 You can check the session summary at any time:
 
 ```ruby

--- a/docs/sql-fingerprints.md
+++ b/docs/sql-fingerprints.md
@@ -1,0 +1,53 @@
+# SQL fingerprints
+
+`AndOne::Fingerprint.generate(sql, adapter: nil)` returns a normalized SQL shape. `Detection#fingerprint` hashes that shape and its table name for aggregation and `fingerprint:` ignore rules. The detector and detection identity both pass their adapter metadata to the normalizer.
+
+## Normalization version 2
+
+Version 2 scans SQL into tokens before normalizing it:
+
+- SQL words are lowercased; quoted identifiers retain their exact case, quoting, and content. Quoted and unquoted identifiers are deliberately not assumed equivalent.
+- Numbers (including decimal/exponent and common hexadecimal/binary forms), string literals, booleans, and bind placeholders become `?`.
+- PostgreSQL `$1` parameters, dollar-quoted strings with ASCII tags, and `E'...'` escapes are recognized.
+- SQLite `?NNN`, `:name`, `@name`, and `$name` parameters, bracket identifiers, and blob literals are recognized with the SQLite adapter.
+- MySQL/Trilogy backslash-escaped strings, double-quoted strings, backtick identifiers, and `#` comments are recognized with those adapters. MySQL `--` starts a comment only when followed by whitespace or the end of input.
+- Doubled quote escapes are handled inside strings and identifiers. Comment-looking text inside either is never processed as a comment.
+- Ordinary comments are removed between tokens, never by concatenating surrounding words. Nested block comments are recognized. Executable comments (`/*! ... */`) and optimizer hints (`/*+ ... */`) are retained verbatim rather than silently discarded.
+- Whitespace between tokens is canonicalized to one space. Whitespace inside quoted identifiers remains significant.
+- Scalar `IN` lists containing only normalized values/parameters collapse to `( ? )`. Subqueries, row tuples, and lists containing expressions do not.
+- `NULL`, operators, `LIMIT`/`OFFSET` clauses, and the shape of `VALUES` rows are preserved rather than conflated with different query structures.
+- Unterminated quotes/comments are retained as opaque text, not silently erased.
+
+For example:
+
+```ruby
+AndOne::Fingerprint.generate(
+  'SELECT * FROM posts WHERE id IN ($1, $2)',
+  adapter: "postgresql"
+)
+# => "select * from posts where id in ( ? )"
+```
+
+The normalizer does not execute SQL and does not change application queries.
+
+## Compatibility and ignore migration
+
+Version 2 changes normalized output and therefore **can change existing detection fingerprints**, including many ordinary queries because token spacing and quoted identifiers are now preserved differently. `NORMALIZATION_VERSION` is `2`.
+
+When upgrading:
+
+1. Reset stale aggregate data with `AndOne.aggregate.reset!` once for the intended shared session, not concurrently from each worker.
+2. Reproduce previously ignored findings, inspect them, and replace old `fingerprint:` entries with newly reported IDs. Temporarily remove an old rule if necessary while validating the replacement.
+3. Existing `gem:`, `path:`, and `query:` rules retain their existing behavior; they do not use normalized fingerprints.
+
+Legacy fingerprints are **not** silently accepted as aliases: the old normalizer could conflate distinct queries, so carrying those identities forward would preserve incorrect suppressions. Existing aggregate files do not migrate identities automatically; without a reset they may show both old and new entries.
+
+## Boundaries
+
+This is a lexical normalizer, not a complete SQL parser or proof of semantic equivalence. It does not determine whether an N+1 exists, choose an execution plan, or act as a security-grade SQL redactor.
+
+Adapter-free calls use a conservative default: standard doubled-quote strings, double-quoted/backtick identifiers, PostgreSQL dollar forms, `?` parameters, and `--` comments. Pass the actual adapter for dialect-sensitive syntax such as MySQL `#` comments versus PostgreSQL `#` operators.
+
+Session-specific modes are not inferred. In particular, MySQL `ANSI_QUOTES`/`NO_BACKSLASH_ESCAPES`, PostgreSQL legacy `standard_conforming_strings=off`, and SQLite's double-quoted-string fallback are not modeled. Extended SQLite parameter syntax, arbitrary custom PostgreSQL operators, Unicode escape decoding, and vendor-specific grammar may remain distinct or unsupported. Unknown characters are retained as tokens. Do not rely on equivalent queries in different dialects receiving identical fingerprints.
+
+Golden tests and deterministic randomized tests cover supported lexical behavior. Real multi-database compatibility coverage is tracked separately in issue #19.

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "and_one/version"
+require_relative "and_one/reporting"
 
 module AndOne
   class NPlus1Error < StandardError; end
+
+  extend Reporting
 
   # Mutex for protecting lazy singleton initialization (aggregate, ignore_list)
   # and serializing report output so multi-line messages don't interleave
@@ -163,58 +166,6 @@ module AndOne
 
     def thread_state
       Thread.current
-    end
-
-    def report(detections) # rubocop:disable Metrics
-      # Record to aggregate and only report NEW unique detections
-      detections = detections.select { |d| aggregate.record(d) }
-      return if detections.empty?
-
-      # Buffer detections for logfile output (written on process exit)
-      logfile_writer&.record(detections)
-
-      cleaner = backtrace_cleaner || default_backtrace_cleaner
-
-      formatter = Formatter.new(backtrace_cleaner: cleaner)
-      message = formatter.format(detections)
-
-      # Serialize all output through a mutex so multi-line messages
-      # from concurrent Puma threads don't interleave.
-      @report_mutex.synchronize do
-        # JSON logging for log aggregation services
-        if json_logging
-          json_formatter = JsonFormatter.new(backtrace_cleaner: cleaner)
-          json_output = json_formatter.format(detections)
-
-          if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
-            Rails.logger.warn(json_output)
-          else
-            warn(json_output)
-          end
-        end
-
-        notifications_callback&.call(detections, message)
-
-        # GitHub Actions annotations
-        if ENV["GITHUB_ACTIONS"]
-          detections.each do |d|
-            file, line = parse_frame_location(d.fix_location || d.origin_frame)
-            query_count = "#{d.count} queries to `#{d.table_name || "unknown"}`"
-            if file
-              $stdout.puts "::warning file=#{file},line=#{line || 1}::N+1 detected: #{query_count}. Add `.includes(:#{suggest_association_name(d)})` to fix."
-            else
-              $stdout.puts "::warning ::N+1 detected: #{query_count}."
-            end
-          end
-        end
-
-        raise NPlus1Error, "\n#{message}" if raise_on_detect
-
-        unless json_logging
-          Rails.logger.warn("\n#{message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
-          warn("\n#{message}") if $stderr.tty?
-        end
-      end
     end
 
     def apply_ignore_filter(detections)

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -37,32 +37,19 @@ module AndOne
       return block_given? ? yield : nil if scanning?
 
       start_scan
-
       return unless block_given?
 
+      owned_detector = detector
       begin
         yield
-        detections = detector.finish
-        stop_scan
-        detections = apply_ignore_filter(detections)
-        report(detections) if detections.any?
-        detections
-      rescue Exception # rubocop:disable Lint/RescueException
-        # On error, clean up without reporting — don't add noise to real errors
-        detector&.send(:unsubscribe)
-        stop_scan
-        raise
+        finish_scan(owned_detector)
+      ensure
+        release_scan(owned_detector)
       end
     end
 
     def finish
-      return [] unless scanning?
-
-      detections = detector.finish
-      stop_scan
-      detections = apply_ignore_filter(detections)
-      report(detections) if detections.any?
-      detections
+      finish_scan(detector)
     end
 
     def scanning?
@@ -71,12 +58,12 @@ module AndOne
 
     def pause
       if block_given?
-        was_scanning = scanning?
+        was_paused = thread_state[:and_one_paused]
         thread_state[:and_one_paused] = true
         begin
           yield
         ensure
-          thread_state[:and_one_paused] = false if was_scanning
+          thread_state[:and_one_paused] = was_paused
         end
       else
         thread_state[:and_one_paused] = true
@@ -155,9 +142,29 @@ module AndOne
       end
     end
 
-    def stop_scan
-      thread_state[:and_one_detector] = nil
-      thread_state[:and_one_paused] = false
+    def finish_scan(owned_detector)
+      return [] unless owned_detector && detector.equal?(owned_detector)
+
+      begin
+        detections = owned_detector.finish
+      ensure
+        release_scan(owned_detector)
+      end
+      detections = apply_ignore_filter(detections)
+      report(detections) if detections.any?
+      detections
+    end
+
+    def release_scan(owned_detector)
+      owned_detector.send(:unsubscribe)
+    rescue StandardError
+      # Cleanup must not replace an application exception or nonlocal exit.
+      nil
+    ensure
+      if detector.equal?(owned_detector)
+        thread_state[:and_one_detector] = nil
+        thread_state[:and_one_paused] = false
+      end
     end
 
     def detector

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -16,7 +16,7 @@ module AndOne
                   :allow_stack_paths, :ignore_queries, :ignore_callers,
                   :min_n_queries, :notifications_callback,
                   :ignore_file_path, :json_logging, :env_thresholds,
-                  :dev_toast, :dev_toast_position,
+                  :dev_toast, :dev_toast_position, :aggregate_path,
                   :logfile, :logfile_format
 
     def configure
@@ -41,6 +41,7 @@ module AndOne
         yield
         detections = detector.finish
         stop_scan
+        detections = apply_ignore_filter(detections)
         report(detections) if detections.any?
         detections
       rescue Exception # rubocop:disable Lint/RescueException
@@ -56,6 +57,7 @@ module AndOne
 
       detections = detector.finish
       stop_scan
+      detections = apply_ignore_filter(detections)
       report(detections) if detections.any?
       detections
     end
@@ -88,7 +90,7 @@ module AndOne
 
     def aggregate
       @singleton_mutex.synchronize do
-        @aggregate ||= Aggregate.new
+        @aggregate ||= Aggregate.new(path: aggregate_path)
       end
     end
 
@@ -164,14 +166,6 @@ module AndOne
     end
 
     def report(detections) # rubocop:disable Metrics
-      # Filter out ignored detections
-      detections = detections.reject do |d|
-        ignore_list.ignored?(d, d.raw_caller_strings) ||
-          caller_ignored?(d.raw_caller_strings)
-      end
-
-      return if detections.empty?
-
       # Record to aggregate and only report NEW unique detections
       detections = detections.select { |d| aggregate.record(d) }
       return if detections.empty?
@@ -220,6 +214,13 @@ module AndOne
           Rails.logger.warn("\n#{message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
           warn("\n#{message}") if $stderr.tty?
         end
+      end
+    end
+
+    def apply_ignore_filter(detections)
+      detections.reject do |d|
+        ignore_list.ignored?(d, d.raw_caller_strings) ||
+          caller_ignored?(d.raw_caller_strings)
       end
     end
 

--- a/lib/and_one/aggregate.rb
+++ b/lib/and_one/aggregate.rb
@@ -1,21 +1,31 @@
 # frozen_string_literal: true
 
+require "json"
+require "fileutils"
+require "time"
+
 module AndOne
   # Tracks unique N+1 detections across requests/jobs in a server session.
   # Each unique N+1 (by fingerprint) is only reported once.
   # Subsequent occurrences are silently counted.
   #
+  # Data is stored on disk (JSON) so detections are shared across all Puma
+  # workers in multi-process deployments. File locking ensures consistency.
+  #
   # The aggregate can be queried at any time:
-  #   AndOne.aggregate.summary   # => formatted string
-  #   AndOne.aggregate.detections # => { fingerprint => { detection:, count:, first_seen_at: } }
+  #   AndOne.aggregate.summary    # => formatted string
+  #   AndOne.aggregate.detections # => { fingerprint => Entry }
   #   AndOne.aggregate.reset!
   #
   class Aggregate
     Entry = Struct.new(:detection, :occurrences, :first_seen_at, :last_seen_at)
 
-    def initialize
+    def initialize(path: nil)
+      @dir = path || default_dir
+      @data_path = File.join(@dir, "aggregate.json")
+      @lock_path = File.join(@dir, "aggregate.lock")
       @mutex = Mutex.new
-      @entries = {}
+      FileUtils.mkdir_p(@dir)
     end
 
     # Record a detection. Returns true if this is a NEW unique detection
@@ -23,59 +33,132 @@ module AndOne
     def record(detection)
       fp = detection.fingerprint
 
-      @mutex.synchronize do
-        if @entries.key?(fp)
-          @entries[fp].occurrences += 1
-          @entries[fp].last_seen_at = Time.now
+      with_lock do
+        data = read_data
+
+        if data.key?(fp)
+          data[fp]["occurrences"] += 1
+          data[fp]["last_seen_at"] = Time.now.iso8601
+          write_data(data)
           false
         else
-          @entries[fp] = Entry.new(
-            detection: detection,
-            occurrences: 1,
-            first_seen_at: Time.now,
-            last_seen_at: Time.now
-          )
+          data[fp] = {
+            "detection" => serialize_detection(detection),
+            "occurrences" => 1,
+            "first_seen_at" => Time.now.iso8601,
+            "last_seen_at" => Time.now.iso8601
+          }
+          write_data(data)
           true
         end
       end
     end
 
     def detections
-      @mutex.synchronize { @entries.dup }
+      with_lock do
+        data = read_data
+        data.each_with_object({}) do |(fp, entry_data), result|
+          result[fp] = deserialize_entry(entry_data)
+        end
+      end
     end
 
     def size
-      @mutex.synchronize { @entries.size }
+      with_lock { read_data.size }
     end
 
     def empty?
-      @mutex.synchronize { @entries.empty? }
+      with_lock { read_data.empty? }
     end
 
     def reset!
-      @mutex.synchronize { @entries.clear }
+      with_lock do
+        FileUtils.rm_f(@data_path)
+      end
     end
 
     def summary
-      @mutex.synchronize do
-        return "No N+1 queries detected this session." if @entries.empty?
+      entries = detections
 
-        lines = []
+      return "No N+1 queries detected this session." if entries.empty?
+
+      lines = []
+      lines << ""
+      lines << "🏀 AndOne Session Summary: #{entries.size} unique N+1 pattern#{"s" if entries.size != 1}"
+      lines << ("─" * 60)
+
+      entries.each_with_index do |(fp, entry), i|
+        det = entry.detection
+        lines << "  #{i + 1}) #{det.table_name || "unknown"} — #{entry.occurrences} occurrence#{"s" if entry.occurrences != 1}"
+        lines << "     #{det.sample_query[0, 120]}"
+        lines << "     origin: #{det.origin_frame}" if det.origin_frame
+        lines << "     fingerprint: #{fp}"
         lines << ""
-        lines << "🏀 AndOne Session Summary: #{@entries.size} unique N+1 pattern#{"s" if @entries.size != 1}"
-        lines << ("─" * 60)
+      end
 
-        @entries.each_with_index do |(fp, entry), i|
-          det = entry.detection
-          lines << "  #{i + 1}) #{det.table_name || "unknown"} — #{entry.occurrences} occurrence#{"s" if entry.occurrences != 1}"
-          lines << "     #{det.sample_query[0, 120]}"
-          lines << "     origin: #{det.origin_frame}" if det.origin_frame
-          lines << "     fingerprint: #{fp}"
-          lines << ""
+      lines << ("─" * 60)
+      lines.join("\n")
+    end
+
+    private
+
+    def with_lock
+      @mutex.synchronize do
+        File.open(@lock_path, File::RDWR | File::CREAT) do |lock|
+          lock.flock(File::LOCK_EX)
+          yield
         end
+      end
+    end
 
-        lines << ("─" * 60)
-        lines.join("\n")
+    def read_data
+      return {} unless File.exist?(@data_path)
+
+      JSON.parse(File.read(@data_path))
+    rescue JSON::ParserError
+      {}
+    end
+
+    def write_data(data)
+      tmp_path = "#{@data_path}.tmp"
+      File.write(tmp_path, JSON.generate(data))
+      File.rename(tmp_path, @data_path)
+    end
+
+    def serialize_detection(det)
+      {
+        "queries" => det.queries,
+        "caller_strings" => det.raw_caller_strings,
+        "count" => det.count,
+        "adapter" => det.adapter
+      }
+    end
+
+    def deserialize_entry(entry_data)
+      det_data = entry_data["detection"]
+      det = Detection.new(
+        queries: det_data["queries"],
+        raw_caller_strings: det_data["caller_strings"],
+        count: det_data["count"],
+        adapter: det_data["adapter"]
+      )
+      Entry.new(
+        detection: det,
+        occurrences: entry_data["occurrences"],
+        first_seen_at: parse_time(entry_data["first_seen_at"]),
+        last_seen_at: parse_time(entry_data["last_seen_at"])
+      )
+    end
+
+    def parse_time(str)
+      str ? Time.parse(str) : nil
+    end
+
+    def default_dir
+      if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
+        Rails.root.join("tmp", "and_one").to_s
+      else
+        File.join(Dir.pwd, "tmp", "and_one")
       end
     end
   end

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -31,7 +31,7 @@ module AndOne
     # For location-specific ignoring, use `path:` rules in .and_one_ignore.
     def fingerprint
       @fingerprint ||= begin
-        sql_fp = Fingerprint.generate(sample_query)
+        sql_fp = Fingerprint.generate(sample_query, adapter: adapter)
         Digest::SHA256.hexdigest("#{sql_fp}:#{table_name}")[0, 12]
       end
     end

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -7,9 +7,10 @@ module AndOne
   class Detection
     attr_reader :queries, :caller_locations, :count, :adapter
 
-    def initialize(queries:, caller_locations:, count:, adapter: nil)
+    def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil)
       @queries = queries
       @caller_locations = caller_locations
+      @raw_caller_strings_override = raw_caller_strings
       @count = count
       @adapter = adapter
     end
@@ -37,7 +38,7 @@ module AndOne
 
     # The raw caller strings (before backtrace cleaning)
     def raw_caller_strings
-      @raw_caller_strings ||= caller_locations.map(&:to_s)
+      @raw_caller_strings ||= @raw_caller_strings_override || caller_locations&.map(&:to_s) || []
     end
 
     # The first frame in the call stack that is application code

--- a/lib/and_one/detector.rb
+++ b/lib/and_one/detector.rb
@@ -114,7 +114,7 @@ module AndOne
         next unless callers
 
         # Group by fingerprint to confirm they're actually the same query shape
-        grouped = queries.group_by { |q| Fingerprint.generate(q) }
+        grouped = queries.group_by { |q| Fingerprint.generate(q, adapter: metadata[:connection_adapter]) }
         repeated = grouped.values.select { |group| group.size >= @min_n_queries }
 
         next if repeated.empty?

--- a/lib/and_one/fingerprint.rb
+++ b/lib/and_one/fingerprint.rb
@@ -1,55 +1,47 @@
 # frozen_string_literal: true
 
+require_relative "sql_lexer"
+
 module AndOne
-  # SQL fingerprinting without external dependencies.
-  # Normalizes queries so that the same query shape with different bind values
-  # produces the same fingerprint. Works with PostgreSQL, MySQL, and SQLite.
+  # Version 2 normalizes tokens instead of applying substitutions to raw SQL.
+  # Quoted identifiers and structural clauses are deliberately preserved.
   module Fingerprint
+    NORMALIZATION_VERSION = 2
+
     module_function
 
-    def generate(sql)
-      normalized = sql.dup
-
-      # Remove SQL comments
-      normalized.gsub!(%r{/\*[^!].*?\*/}m, "")
-      normalized.gsub!(/(?:--|#)[^\r\n]*(?=[\r\n]|\z)/, "")
-
-      # Replace double-quoted identifiers with unquoted versions (PostgreSQL/SQLite style)
-      # "posts" -> posts, "posts"."id" -> posts.id
-      normalized.gsub!(/"(\w+)"/, '\1')
-
-      # Replace backtick-quoted identifiers (MySQL style)
-      normalized.gsub!(/`(\w+)`/, '\1')
-
-      # Normalize single-quoted string literals
-      normalized.gsub!("\\'", "")
-      normalized.gsub!(/'(?:[^'\\]|\\.)*'/m, "?")
-
-      # Normalize numbers (standalone, not part of identifiers)
-      normalized.gsub!(/\b\d+(?:\.\d+)?\b/, "?")
-
-      # Normalize booleans and NULL
-      normalized.gsub!(/\b(?:true|false)\b/i, "?")
-      normalized.gsub!(/\bNULL\b/i, "?")
-
-      # Normalize IN lists: IN (?, ?, ?) -> IN (?)
-      normalized.gsub!(/\bIN\s*\(\s*\?(?:\s*,\s*\?)*\s*\)/i, "IN (?)")
-
-      # Normalize VALUES lists
-      normalized.gsub!(/\bVALUES\s*\([\s?,]*\)(?:\s*,\s*\([\s?,]*\))*/i, "VALUES (?)")
-
-      # Normalize whitespace
-      normalized.gsub!(/\s+/, " ")
-      normalized.strip!
-      normalized.downcase!
-
-      # Normalize LIMIT/OFFSET
-      normalized.gsub!(/\blimit \?(?:, ?\?| offset \?)?/, "limit ?")
-
-      # Normalize $1, $2, ... placeholders (PostgreSQL)
-      normalized.gsub!(/\$\d+/, "?")
-
-      normalized
+    def generate(sql, adapter: nil)
+      tokens = SqlLexer.new(sql, adapter: adapter).tokens
+      normalized = []
+      index = 0
+      while index < tokens.size
+        token = tokens[index]
+        normalized << token.text
+        closing = token.kind == :word && token.text == "in" ? parameter_list_end(tokens, index + 1) : nil
+        if closing
+          normalized.push("(", "?", ")")
+          index = closing + 1
+        else
+          index += 1
+        end
+      end
+      normalized.join(" ")
     end
+
+    def parameter_list_end(tokens, index)
+      return unless tokens[index]&.text == "("
+
+      index += 1
+      loop do
+        return unless tokens[index]&.kind == :parameter
+
+        index += 1
+        return index if tokens[index]&.text == ")"
+        return unless tokens[index]&.text == ","
+
+        index += 1
+      end
+    end
+    private_class_method :parameter_list_end
   end
 end

--- a/lib/and_one/middleware.rb
+++ b/lib/and_one/middleware.rb
@@ -10,8 +10,6 @@ module AndOne
   # detected N+1s are injected as a toast notification into HTML responses
   # with a link to the DevUI dashboard.
   class Middleware
-    include ScanHelper
-
     def initialize(app)
       @app = app
     end
@@ -19,23 +17,17 @@ module AndOne
     def call(env)
       return @app.call(env) if !AndOne.enabled? || AndOne.scanning?
 
-      begin
-        AndOne.scan
-        status, headers, body = @app.call(env)
-        detections = AndOne.finish
+      status = headers = body = nil
+      detections = AndOne.scan { status, headers, body = @app.call(env) }
 
-        if AndOne.dev_toast && detections&.any? && html_response?(headers) && status == 200
-          body = inject_toast(body, detections)
-          # Recalculate Content-Length since we modified the body
-          headers.delete("content-length")
-          headers.delete("Content-Length")
-        end
-
-        [status, headers, body]
-      rescue Exception # rubocop:disable Lint/RescueException
-        and_one_quietly_stop
-        raise
+      if AndOne.dev_toast && detections&.any? && html_response?(headers) && status == 200
+        body = inject_toast(body, detections)
+        # Recalculate Content-Length since we modified the body
+        headers.delete("content-length")
+        headers.delete("Content-Length")
       end
+
+      [status, headers, body]
     end
 
     private

--- a/lib/and_one/railtie.rb
+++ b/lib/and_one/railtie.rb
@@ -19,6 +19,9 @@ module AndOne
           # Swallow errors during shutdown to avoid confusing output
         end
 
+        # Reset aggregate on server boot for a fresh session
+        AndOne.aggregate.reset!
+
         # In test, raise by default so N+1s fail the test suite
         AndOne.raise_on_detect = true if Rails.env.test?
 

--- a/lib/and_one/reporting.rb
+++ b/lib/and_one/reporting.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module AndOne
+  # Enforcement applies to every scan; output sinks only receive new findings.
+  module Reporting
+    private
+
+    def report(detections)
+      new_detections = detections.select { |detection| aggregate.record(detection) }
+      report_new(new_detections) unless new_detections.empty?
+      return unless raise_on_detect
+
+      formatter = Formatter.new(backtrace_cleaner: backtrace_cleaner || default_backtrace_cleaner)
+      raise NPlus1Error, "\n#{formatter.format(detections)}"
+    end
+
+    def report_new(detections)
+      logfile_writer&.record(detections)
+      cleaner = backtrace_cleaner || default_backtrace_cleaner
+      message = Formatter.new(backtrace_cleaner: cleaner).format(detections)
+
+      # Keep the existing first-occurrence callback and output contracts.
+      @report_mutex.synchronize do
+        if json_logging
+          json_output = JsonFormatter.new(backtrace_cleaner: cleaner).format(detections)
+          if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+            Rails.logger.warn(json_output)
+          else
+            warn(json_output)
+          end
+        end
+
+        notifications_callback&.call(detections, message)
+        report_annotations(detections) if ENV["GITHUB_ACTIONS"]
+        return if raise_on_detect || json_logging
+
+        Rails.logger.warn("\n#{message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+        warn("\n#{message}") if $stderr.tty?
+      end
+    end
+
+    def report_annotations(detections)
+      detections.each do |detection|
+        file, line = parse_frame_location(detection.fix_location || detection.origin_frame)
+        query_count = "#{detection.count} queries to `#{detection.table_name || "unknown"}`"
+        if file
+          hint = "Add `.includes(:#{suggest_association_name(detection)})` to fix."
+          $stdout.puts "::warning file=#{file},line=#{line || 1}::N+1 detected: #{query_count}. #{hint}"
+        else
+          $stdout.puts "::warning ::N+1 detected: #{query_count}."
+        end
+      end
+    end
+  end
+end

--- a/lib/and_one/scan_helper.rb
+++ b/lib/and_one/scan_helper.rb
@@ -1,32 +1,14 @@
 # frozen_string_literal: true
 
 module AndOne
-  # Shared scan lifecycle for middleware/hooks.
-  # Wraps a block in AndOne.scan with clean error handling
-  # that never interferes with the original exception.
+  # Preserve the application's return value while using scan's owned lifecycle.
   module ScanHelper
     private
 
     def and_one_wrap
-      return yield if !AndOne.enabled? || AndOne.scanning?
-
-      begin
-        AndOne.scan
-        result = yield
-        AndOne.finish
-        result
-      rescue Exception # rubocop:disable Lint/RescueException
-        and_one_quietly_stop
-        raise
-      end
-    end
-
-    def and_one_quietly_stop
-      Thread.current[:and_one_detector]&.send(:unsubscribe)
-      Thread.current[:and_one_detector] = nil
-      Thread.current[:and_one_paused] = false
-    rescue StandardError
-      nil
+      result = nil
+      AndOne.scan { result = yield }
+      result
     end
   end
 end

--- a/lib/and_one/sql_lexer.rb
+++ b/lib/and_one/sql_lexer.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "strscan"
+
+module AndOne
+  # A lexical scanner, not a SQL parser. Unknown syntax is retained, not discarded.
+  class SqlLexer
+    Token = Struct.new(:kind, :text)
+    NUMBER = /(?:0[xX][0-9a-fA-F]+|0[bB][01]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)/
+    WORD = /[\p{L}_][\p{L}\p{N}_$]*/
+    OPERATOR = %r{::|->>|->|#>>|#>|\?\||\?&|<=|>=|<>|!=|\|\||&&|:=|[-+*/%<>=~!@#^&|?]}
+
+    def initialize(sql, adapter: nil)
+      @scanner = StringScanner.new(sql)
+      @mysql = adapter.to_s.match?(/mysql|trilogy/i)
+      @sqlite = adapter.to_s.match?(/sqlite/i)
+      @postgres = adapter.to_s.match?(/postgres/i)
+    end
+
+    def tokens
+      result = []
+      until @scanner.eos?
+        next if @scanner.scan(/\s+/)
+
+        token = next_token
+        result << token if token
+      end
+      result
+    end
+
+    private
+
+    def next_token
+      return block_comment if @scanner.peek(2) == "/*"
+      return line_comment if line_comment?
+      return quoted_literal if @scanner.check(/(?:[eEnNbBxX])?'/)
+      return dollar_literal if @scanner.check(/\$(?:[A-Za-z_][A-Za-z_0-9]*)?\$/)
+      return quoted_identifier if @scanner.check(/["`]/) || (@sqlite && @scanner.peek(1) == "[")
+      return Token.new(:parameter, "?") if parameter?
+      return Token.new(:parameter, "?") if @scanner.scan(NUMBER)
+
+      word = @scanner.scan(WORD)
+      return word_token(word) if word
+
+      Token.new(:symbol, @scanner.scan(OPERATOR) || @scanner.getch)
+    end
+
+    def line_comment?
+      (@scanner.peek(2) == "--" && (!@mysql || @scanner.check(/--(?:\s|\z)/))) ||
+        (@mysql && @scanner.peek(1) == "#")
+    end
+
+    def line_comment
+      @scanner.scan(/[^\r\n]*/)
+      nil
+    end
+
+    def block_comment
+      start = @scanner.pos
+      @scanner.pos += 2
+      significant = @scanner.check(/[!+]/)
+      depth = 1
+      while depth.positive? && !@scanner.eos?
+        delimiter = @scanner.scan_until(%r{/\*|\*/})
+        unless delimiter
+          @scanner.terminate
+          break
+        end
+        depth += delimiter.end_with?("/*") ? 1 : -1
+      end
+      # Executable comments and optimizer hints must not be erased as trivia.
+      raw_token(start, :opaque) if significant || depth.positive?
+    end
+
+    def quoted_literal
+      start = @scanner.pos
+      prefix = @scanner.scan(/[eEnNbBxX](?=')/)
+      escaped = @mysql || prefix&.casecmp?("e")
+      closed = consume_quoted?("'", escaped: escaped)
+      closed ? Token.new(:parameter, "?") : raw_token(start, :opaque)
+    end
+
+    def dollar_literal
+      start = @scanner.pos
+      delimiter = @scanner.scan(/\$(?:[A-Za-z_][A-Za-z_0-9]*)?\$/)
+      if @scanner.scan_until(Regexp.new(Regexp.escape(delimiter)))
+        Token.new(:parameter, "?")
+      else
+        @scanner.terminate
+        raw_token(start, :opaque)
+      end
+    end
+
+    def quoted_identifier
+      start = @scanner.pos
+      opening = @scanner.peek(1)
+      closing = opening == "[" ? "]" : opening
+      closed = consume_quoted?(closing, escaped: @mysql)
+      if closed && @mysql && opening == '"'
+        Token.new(:parameter, "?")
+      else
+        raw_token(start, closed ? :identifier : :opaque)
+      end
+    end
+
+    def consume_quoted?(closing, escaped:)
+      @scanner.getch
+      until @scanner.eos?
+        character = @scanner.getch
+        if escaped && character == "\\"
+          @scanner.getch
+        elsif character == closing
+          return true unless @scanner.peek(1) == closing
+
+          @scanner.getch # SQL doubled quote escape
+        end
+      end
+      false
+    end
+
+    def parameter?
+      return true if @scanner.scan(/\$\d+/)
+      return true if @sqlite && @scanner.scan(/(?:[:@$][A-Za-z_][A-Za-z_0-9]*|\?\d*)/)
+
+      !@postgres && @scanner.scan(/\?(?![|&])/)
+    end
+
+    def word_token(word)
+      normalized = word.downcase
+      kind = %w[true false].include?(normalized) ? :parameter : :word
+      Token.new(kind, kind == :parameter ? "?" : normalized)
+    end
+
+    def raw_token(start, kind)
+      Token.new(kind, @scanner.string.byteslice(start...@scanner.pos))
+    end
+  end
+end

--- a/lib/and_one/version.rb
+++ b/lib/and_one/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AndOne
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/test/test_enforcement.rb
+++ b/test/test_enforcement.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestEnforcement < Minitest::Test
+  include AndOneTestHelper
+  include AndOne::MinitestHelper
+
+  def setup
+    super
+    seed_data!
+    @reports = []
+    AndOne.notifications_callback = ->(detections, _message) { @reports << detections }
+    AndOne.raise_on_detect = true
+  end
+
+  def teardown
+    Comment.delete_all
+    Post.delete_all
+    Author.delete_all
+    super
+  end
+
+  def test_every_scan_raises_but_only_first_occurrence_is_reported
+    2.times do
+      error = assert_raises(AndOne::NPlus1Error) { AndOne.scan { load_comments } }
+      assert_includes error.message, "comments"
+    end
+
+    assert_equal 1, @reports.size
+    assert_equal 2, AndOne.aggregate.detections.values.first.occurrences
+  end
+
+  def test_non_raising_scan_does_not_suppress_later_failure
+    AndOne.raise_on_detect = false
+    AndOne.scan { load_comments }
+    AndOne.raise_on_detect = true
+
+    assert_raises(AndOne::NPlus1Error) { AndOne.scan { load_comments } }
+  end
+
+  def test_matcher_does_not_suppress_later_failure
+    assert_n_plus_one { load_comments }
+
+    assert_raises(AndOne::NPlus1Error) { AndOne.scan { load_comments } }
+  end
+
+  def test_persisted_aggregate_does_not_suppress_manual_finish_failure
+    assert_raises(AndOne::NPlus1Error) { AndOne.scan { load_comments } }
+    AndOne.instance_variable_set(:@aggregate, nil)
+    AndOne.scan
+    load_comments
+
+    assert_raises(AndOne::NPlus1Error) { AndOne.finish }
+    refute AndOne.scanning?
+    assert_equal 1, @reports.size
+  end
+
+  def test_error_contains_known_and_new_findings
+    assert_raises(AndOne::NPlus1Error) { AndOne.scan { load_comments } }
+    error = assert_raises(AndOne::NPlus1Error) do
+      AndOne.scan do
+        load_comments
+        Post.all.each(&:author)
+      end
+    end
+
+    assert_includes error.message, "comments"
+    assert_includes error.message, "authors"
+    assert_equal ["authors"], @reports.last.map(&:table_name)
+  end
+
+  def test_ignore_file_excludes_findings_from_all_sinks_and_scan_results
+    AndOne.ignore_file_path = File.join(@aggregate_tmpdir, ".and_one_ignore")
+    File.write(AndOne.ignore_file_path, "query:comments\n")
+    AndOne.reload_ignore_file!
+    AndOne.logfile = File.join(@aggregate_tmpdir, "findings.log")
+    AndOne.json_logging = true
+
+    stdout, stderr = capture_io do
+      assert_empty(AndOne.scan { load_comments })
+      AndOne.scan
+      load_comments
+      assert_empty AndOne.finish
+      AndOne.logfile_writer.flush!
+    end
+
+    assert_empty stdout
+    assert_empty stderr
+    assert_empty @reports
+    assert AndOne.aggregate.empty?
+    refute File.exist?(AndOne.logfile)
+  end
+
+  def test_caller_ignores_do_not_raise_or_report
+    AndOne.ignore_callers = [/test_enforcement/]
+
+    assert_empty(AndOne.scan { load_comments })
+    assert_empty @reports
+    assert AndOne.aggregate.empty?
+  end
+
+  private
+
+  def load_comments
+    Post.all.each { |post| post.comments.to_a }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,8 @@ require "active_record"
 require "active_support"
 require "and_one"
 require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
 
 # Set up an in-memory SQLite database for testing
 ActiveRecord::Base.establish_connection(
@@ -74,6 +76,8 @@ module AndOneTestHelper
     AndOne.logfile_format = nil
     AndOne.ignore_file_path = nil
     AndOne.reload_ignore_file!
+    @aggregate_tmpdir = Dir.mktmpdir("and_one_test")
+    AndOne.aggregate_path = @aggregate_tmpdir
     AndOne.instance_variable_set(:@aggregate, nil)
     AndOne.instance_variable_set(:@logfile_writer, nil)
 
@@ -86,5 +90,6 @@ module AndOneTestHelper
     super
     Thread.current[:and_one_detector] = nil
     Thread.current[:and_one_paused] = false
+    FileUtils.rm_rf(@aggregate_tmpdir) if @aggregate_tmpdir
   end
 end

--- a/test/test_scan_lifecycle.rb
+++ b/test/test_scan_lifecycle.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestScanLifecycle < Minitest::Test
+  include AndOneTestHelper
+
+  class Wrapper
+    include AndOne::ScanHelper
+
+    def call(&)
+      and_one_wrap(&)
+    end
+  end
+
+  def setup
+    super
+    @listeners = sql_listeners
+    @reports = []
+    AndOne.notifications_callback = ->(*) { @reports << true }
+  end
+
+  def teardown
+    refute AndOne.scanning?
+    assert_equal @listeners, sql_listeners
+    super
+  end
+
+  def test_owned_wrappers_release_on_normal_completion
+    wrappers.each do |wrapper|
+      wrapper.call { record_queries }
+      assert_released
+    end
+  end
+
+  def test_owned_wrappers_release_on_throw_without_reporting
+    wrappers.each do |wrapper|
+      result = catch(:done) do
+        wrapper.call do
+          record_queries
+          throw :done, :thrown
+        end
+      end
+      assert_equal :thrown, result
+      assert_released
+    end
+    assert_empty @reports
+  end
+
+  def test_owned_wrappers_release_on_return_without_reporting
+    wrappers.each do |wrapper|
+      assert_equal :returned, return_from(wrapper)
+      assert_released
+    end
+    assert_empty @reports
+  end
+
+  def test_owned_wrappers_release_on_break_without_reporting
+    wrappers.each do |wrapper|
+      result = wrapper.call do
+        record_queries
+        break :broken
+      end
+      assert_equal :broken, result
+      assert_released
+    end
+    assert_empty @reports
+  end
+
+  def test_owned_wrappers_preserve_original_exception_and_backtrace
+    wrappers.each do |wrapper|
+      original = RuntimeError.new("application failure")
+      original.set_backtrace(["app/service.rb:42"])
+      caught = assert_raises(RuntimeError) do
+        wrapper.call do
+          record_queries
+          raise original
+        end
+      end
+      assert_same original, caught
+      assert_equal ["app/service.rb:42"], caught.backtrace
+      assert_released
+    end
+    assert_empty @reports
+  end
+
+  def test_nested_wrappers_leave_outer_scan_and_pause_intact
+    AndOne.scan do
+      outer = Thread.current[:and_one_detector]
+      AndOne.pause do
+        wrappers.each do |wrapper|
+          catch(:done) { wrapper.call { throw :done } }
+          assert_same outer, Thread.current[:and_one_detector]
+          assert AndOne.paused?
+        end
+      end
+    end
+  end
+
+  def test_finishing_and_replacing_scan_does_not_let_outer_wrapper_stop_replacement
+    wrappers.each do |wrapper|
+      wrapper.call do
+        AndOne.finish
+        AndOne.scan
+      end
+      assert AndOne.scanning?
+      assert_empty AndOne.finish
+      assert_released
+    end
+  end
+
+  def test_manual_finish_releases_even_when_analysis_raises
+    AndOne.scan
+    owned = Thread.current[:and_one_detector]
+    owned.define_singleton_method(:analyze) { raise "analysis failure" }
+
+    assert_raises(RuntimeError) { AndOne.finish }
+    assert_nil owned.instance_variable_get(:@subscriber)
+    assert_released
+    assert_empty AndOne.finish
+  end
+
+  def test_nested_pauses_restore_outer_state
+    AndOne.scan do
+      AndOne.pause do
+        AndOne.pause { assert AndOne.paused? }
+        assert AndOne.paused?
+      end
+      refute AndOne.paused?
+      AndOne.pause
+      AndOne.pause { assert AndOne.paused? }
+      assert AndOne.paused?
+      AndOne.resume
+      refute AndOne.paused?
+    end
+  end
+
+  def test_pause_outside_scan_restores_prior_state_on_all_exits
+    refute AndOne.paused?
+    AndOne.pause { assert AndOne.paused? }
+    refute AndOne.paused?
+    catch(:done) { AndOne.pause { throw :done } }
+    refute AndOne.paused?
+    assert_raises(RuntimeError) { AndOne.pause { raise "failure" } }
+    refute AndOne.paused?
+    AndOne.pause
+    assert_raises(RuntimeError) { AndOne.pause { raise "failure" } }
+    assert AndOne.paused?
+    AndOne.resume
+  end
+
+  private
+
+  def wrappers
+    [
+      ->(&block) { AndOne.scan(&block) },
+      Wrapper.new,
+      lambda do |&block|
+        app = lambda do |_env|
+          block.call
+          [200, {}, ["OK"]]
+        end
+        AndOne::Middleware.new(app).call({})
+      end
+    ]
+  end
+
+  def return_from(wrapper)
+    wrapper.call do
+      record_queries
+      return :returned
+    end
+  end
+
+  def record_queries
+    2.times do
+      ActiveSupport::Notifications.instrument("sql.active_record", sql: "SELECT * FROM comments WHERE post_id = 1", name: "Load")
+    end
+  end
+
+  def assert_released
+    refute AndOne.scanning?
+    refute AndOne.paused?
+    assert_equal @listeners, sql_listeners
+  end
+
+  def sql_listeners
+    ActiveSupport::Notifications.notifier.listeners_for("sql.active_record").dup
+  end
+end

--- a/test/test_sql_normalization.rb
+++ b/test/test_sql_normalization.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSqlNormalization < Minitest::Test
+  def test_postgres_golden_queries
+    cases = {
+      "SELECT * FROM posts WHERE id IN ($1, $2)" => "select * from posts where id in ( ? )",
+      "SELECT * FROM posts WHERE id IN (1, 2, 3)" => "select * from posts where id in ( ? )",
+      "SELECT 1.25e-3, .5, 12., 0xFF, 0b10" => "select ? , ? , ? , ? , ?",
+      "SELECT $1::integer, $2::text" => "select ? :: integer , ? :: text",
+      "SELECT 'hello#world', 'a--b', 'c/*d*/e' FROM posts" => "select ? , ? , ? from posts",
+      "SELECT 'it''s fine', E'it\\'s fine' FROM posts" => "select ? , ? from posts",
+      "SELECT $$hello -- /* # world$$, $tag$it's fine$tag$" => "select ? , ?",
+      'SELECT "Title", "a""b", "a--#/*b*/", public."posts" FROM "Posts"' =>
+        'select "Title" , "a""b" , "a--#/*b*/" , public . "posts" from "Posts"',
+      "SELECT/* outer /* inner */ comment */id FROM posts-- end\nWHERE id=42" => "select id from posts where id = ?",
+      "SELECT/*comment*/foo/*comment*/bar" => "select foo bar",
+      "SELECT payload #>> '{a,b}', payload ? 'key', payload ?| array['a']" => "select payload #>> ? , payload ? ? , payload ?| array [ ? ]",
+      "SELECT * FROM posts WHERE deleted_at IS NULL AND active = TRUE" => "select * from posts where deleted_at is null and active = ?"
+    }
+    cases.each { |sql, expected| assert_equal expected, normalize(sql, "postgresql"), sql }
+  end
+
+  def test_mysql_golden_queries
+    cases = {
+      "SELECT `posts`.`id` FROM `posts` WHERE id IN (?, ?, ?)" => "select `posts` . `id` from `posts` where id in ( ? )",
+      "SELECT 'it\\'s # fine', \"a--b\" FROM posts # comment\nWHERE id=2" => "select ? , ? from posts where id = ?",
+      "SELECT `a``b`, `a#--b` FROM posts" => "select `a``b` , `a#--b` from posts",
+      "SELECT 2--1" => "select ? - - ?",
+      "SELECT 2-- comment\nFROM posts" => "select ? from posts",
+      "SELECT /*! STRAIGHT_JOIN */ id FROM posts" => "select /*! STRAIGHT_JOIN */ id from posts",
+      "SELECT /*+ MAX_EXECUTION_TIME(1000) */ id FROM posts" => "select /*+ MAX_EXECUTION_TIME(1000) */ id from posts"
+    }
+    cases.each { |sql, expected| assert_equal expected, normalize(sql, "mysql2"), sql }
+    assert_equal "select ?", normalize('SELECT "literal"', "trilogy")
+  end
+
+  def test_sqlite_golden_queries
+    cases = {
+      "SELECT [Title], `a``b`, \"a\"\"b\" FROM [Posts]" => 'select [Title] , `a``b` , "a""b" from [Posts]',
+      "SELECT * FROM posts WHERE id IN (?1, :second, @third, $fourth)" => "select * from posts where id in ( ? )",
+      "SELECT X'ABCD', 'it''s fine', '\\' FROM posts" => "select ? , ? , ? from posts",
+      "SELECT * FROM posts WHERE id IN (SELECT post_id FROM comments)" => "select * from posts where id in ( select post_id from comments )"
+    }
+    cases.each { |sql, expected| assert_equal expected, normalize(sql, "sqlite3"), sql }
+  end
+
+  def test_quoted_identifier_and_structural_distinctions
+    pairs = [
+      ['SELECT "Title" FROM posts', 'SELECT "title" FROM posts'],
+      ['SELECT "a b" FROM posts', 'SELECT "a  b" FROM posts'],
+      ['SELECT "a.b" FROM posts', 'SELECT "a"."b" FROM posts'],
+      ['SELECT "a" FROM posts', "SELECT a FROM posts"],
+      ["SELECT * FROM posts WHERE id = 1", "SELECT * FROM posts WHERE id > 1"],
+      ["SELECT * FROM posts WHERE id IS NULL", "SELECT * FROM posts WHERE id IS TRUE"],
+      ["SELECT * FROM posts LIMIT 1", "SELECT * FROM posts LIMIT 1 OFFSET 2"],
+      ["INSERT INTO posts VALUES (1, 2)", "INSERT INTO posts VALUES (1), (2)"],
+      ["SELECT * FROM posts WHERE id IN (1, 2)", "SELECT * FROM posts WHERE id IN (1, other_id)"],
+      ["SELECT * FROM posts WHERE id IN (1, 2)", "SELECT * FROM posts WHERE id IN ((1, 2))"]
+    ]
+    pairs.each { |left, right| refute_equal normalize(left), normalize(right), "#{left} vs #{right}" }
+  end
+
+  def test_literal_contents_are_not_rewritten_as_query_structure
+    assert_equal "select ?", normalize("SELECT 'IN (1, 2) LIMIT 5 OFFSET 2'")
+    assert_equal 'select "IN (1, 2)"', normalize('SELECT "IN (1, 2)"')
+    assert_equal "select a # ?", normalize("SELECT a # 2", "postgresql")
+  end
+
+  def test_unterminated_constructs_are_preserved_instead_of_silently_removed
+    ["SELECT 'unfinished", 'SELECT "unfinished', "SELECT $tag$unfinished", "SELECT /* unfinished"].each do |sql|
+      assert_equal sql.sub("SELECT", "select"), normalize(sql)
+    end
+  end
+
+  def test_large_literals_and_lists
+    assert_equal "select ?", normalize("SELECT '#{"a#--/*'".gsub("'", "''") * 10_000}'")
+    assert_equal "select * from posts where id in ( ? )", normalize("SELECT * FROM posts WHERE id IN (#{Array.new(10_000, "1").join(",")})")
+    assert_equal "select /* #{"x" * 100_000}", normalize("SELECT /* #{"x" * 100_000}")
+  end
+
+  def test_deterministic_whitespace_and_literal_invariance
+    random = Random.new(42)
+    separators = [" ", "\n", "\t", "/**/", " /* comment */ "]
+    literals = ["'hello#world'", "'a--b'", "'it''s fine'", "$tag$/* hi */$tag$", "1.2e-3"]
+    100.times do
+      tokens = ["SELECT", "*", "FROM", "posts", "WHERE", "id", "IN", "(", random.rand(100).to_s,
+                ",", random.rand(100).to_s, ")", "AND", "title", "=", literals.sample(random: random)]
+      sql = tokens.map { |token| "#{token}#{separators.sample(random: random)}" }.join
+      assert_equal "select * from posts where id in ( ? ) and title = ?", normalize(sql, "postgresql")
+    end
+  end
+
+  def test_does_not_mutate_input
+    sql = 'SELECT "Title" FROM posts WHERE id = $1'
+    assert_equal 'select "Title" from posts where id = ?', normalize(sql)
+    assert_equal 'SELECT "Title" FROM posts WHERE id = $1', sql
+  end
+
+  def test_detection_identity_uses_adapter_lexical_rules
+    left = AndOne::Detection.new(queries: ['SELECT * FROM posts WHERE title = "first"'], count: 2, adapter: "mysql2")
+    right = AndOne::Detection.new(queries: ['SELECT * FROM posts WHERE title = "second"'], count: 2, adapter: "mysql2")
+    assert_equal left.fingerprint, right.fingerprint
+  end
+
+  private
+
+  def normalize(sql, adapter = nil)
+    AndOne::Fingerprint.generate(sql, adapter: adapter)
+  end
+end

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -208,7 +208,8 @@ class TestThreadSafety < Minitest::Test
   # Verify aggregate.record is atomic — concurrent record calls should
   # not lose counts.
   def test_aggregate_record_atomicity
-    aggregate = AndOne::Aggregate.new
+    atomicity_dir = Dir.mktmpdir("and_one_atomicity")
+    aggregate = AndOne::Aggregate.new(path: atomicity_dir)
 
     # Get a real detection to use
     detections = AndOne.scan do
@@ -229,6 +230,8 @@ class TestThreadSafety < Minitest::Test
     expected = THREAD_COUNT * record_count
     assert_equal expected, entry.occurrences,
                  "Expected #{expected} occurrences, got #{entry.occurrences} (lost updates!)"
+  ensure
+    FileUtils.rm_rf(atomicity_dir)
   end
 
   # Verify that notifications_callback is called safely from concurrent threads.


### PR DESCRIPTION
## Summary

Preserves the pending 0.4.0 work and fixes the three highest-priority correctness issues from the codebase review.

### Previously saved work
- Persist aggregate findings as JSON on disk for cross-worker sharing.
- Apply ignore filters consistently to scan/finish results, reporting, and toast notifications.
- Add aggregate-path configuration and detection deserialization.

### Correctness fixes
- **Enforcement:** every violating scan raises when configured, regardless of aggregate history. Logs, annotations, logfile output, and callbacks retain first-occurrence deduplication.
- **Lifecycle:** ownership-aware `ensure` cleanup handles exceptions, `return`, `break`, and `throw`. Request/job wrappers reuse the block-scan lifecycle; nested pauses restore their previous state.
- **SQL normalization:** replace chained regex substitutions with dialect-aware lexical tokens. Correctly handle PostgreSQL placeholders, comments inside literals, quoted identifiers, scalar IN lists, and structural distinctions.
- Extract reporting into its own module, resolving the existing ModuleLength lint failure.

Fixes #2
Fixes #3
Fixes #4

## Validation

`bundle exec rake`:
- 177 tests, 667 assertions
- 0 failures, 0 errors, 0 skips
- RuboCop: no offenses

Regression coverage includes persisted aggregate enforcement, matcher/non-raising scan interactions, ignored reporting sinks, nonlocal scan exits, subscriber cleanup, nested/replacement scans, SQL dialect golden cases, large inputs, and deterministic randomized normalization checks.

## Migration and limitations

- Normalization version 2 can change detection fingerprints. Reset stale aggregate data and regenerate affected `fingerprint:` ignore rules. See `docs/sql-fingerprints.md` for migration instructions and supported syntax.
- SQL dialect coverage here is lexical; real PostgreSQL/MySQL execution coverage remains tracked in #19.
- This PR preserves the pending disk-storage design rather than claiming to resolve its remaining issues: initializer configuration order (#7), shared session lifecycle (#8), bounded storage/failure handling (#9), and SQL privacy (#10) remain follow-ups.
- The branch includes the original 0.4.0 version/changelog changes; this PR does not publish a gem release.
