### PR TITLE
Fix standalone loading and scan-local test matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ### Fixed
 
+- Load runtime dependencies explicitly for standalone ActiveRecord use and register Rails/RSpec integrations safely in either require order (#18).
+- Keep test matcher capture scan-local without mutating global reporting settings; count successful Minitest assertions and reject matchers inside active scans with a clear error (#13).
 - Enforce `raise_on_detect` for every violating scan, independently of first-occurrence reporting and aggregate history (#2).
 - Release owned scans on exceptions and nonlocal exits; preserve outer scans and nested pause state (#3).
 - Tokenize SQL before fingerprint normalization, fixing PostgreSQL bind placeholders and comment characters inside quoted text (#4). Preserve quoted identifiers and structural distinctions.
 
 ### Changed
 
+- Package only runtime Ruby files and documentation; remove the placeholder RBS file (#18).
+- Matchers no longer report or consume aggregate deduplication; ignores and disabled-state behavior still apply (#13).
 - **Fingerprint migration:** normalization version 2 can change detection IDs. Reset stale aggregate data and regenerate affected `fingerprint:` ignore rules. See [SQL fingerprints](docs/sql-fingerprints.md) for details and dialect limitations.
 
 ## [0.4.0] - 2026-03-05

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ gem "rubocop", "~> 1.21"
 
 # Test dependencies — these are what Rails provides, not external deps
 gem "rails", ">= 7.0"
+gem "rspec", "~> 3.13"
 gem "sqlite3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
+    diff-lcs (1.6.2)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
@@ -213,6 +214,19 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
     rubocop (1.85.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -271,6 +285,7 @@ DEPENDENCIES
   minitest (~> 5.16)
   rails (>= 7.0)
   rake (~> 13.0)
+  rspec (~> 3.13)
   rubocop (~> 1.21)
   sqlite3
 
@@ -297,6 +312,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
@@ -349,6 +365,11 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rubocop (1.85.0) sha256=317407feb681a07d54f64d2f9e1d6b6af1ce7678e51cd658e3ad8bd66da48c01
   rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ end
 
 That's it. AndOne automatically activates in development and test environments via a Railtie.
 
+## Ruby and ORM support
+
+AndOne requires Ruby 3.2+ and ActiveRecord/ActiveSupport/Railties 7.0+ (choose versions compatible with your Ruby). Rails applications get automatic request/job integration. Outside a Rails application, “plain Ruby” support means **ActiveRecord SQL instrumentation**, not arbitrary database clients or other ORMs such as Sequel. Railties remains a runtime dependency; RSpec is optional and only needed for `and_one/rspec`. No public RBS signatures are currently shipped.
+
+A standalone script can use:
+
+```ruby
+require "and_one"       # loads its ActiveRecord and Railtie dependencies itself
+require "sqlite3"       # install your chosen database adapter separately
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "app.sqlite3")
+# Define/load your ActiveRecord models, e.g. Post has_many :comments.
+AndOne.configure do |config|
+  config.enabled = true
+  config.raise_on_detect = false
+end
+
+detections = AndOne.scan do
+  Post.all.each { |post| post.comments.to_a }
+end
+puts "Detected #{detections.size} repeated-query patterns"
+```
+
+Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans persist findings under `tmp/and_one` by default; set `aggregate_path` before the first scan to change it. `require "and_one"` is safe before or after loading Rails.
+
 ## What You'll See
 
 When an N+1 is detected, you get output like:
@@ -136,7 +161,7 @@ This is especially useful for **N+1s coming from gems** where you can't add `.in
 
 In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique pattern is reported only once per server session. Subsequent occurrences are silently counted.
 
-Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan or matcher.
+Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan. Test matchers do not report or consume first-occurrence deduplication.
 
 You can check the session summary at any time:
 
@@ -199,7 +224,7 @@ end
 
 ```ruby
 # In spec_helper.rb or rails_helper.rb
-require "and_one/rspec"
+require "and_one/rspec" # loads RSpec core and registers the helper, in either require order
 
 # Then in your specs
 RSpec.describe "Posts" do
@@ -217,7 +242,9 @@ RSpec.describe "Posts" do
 end
 ```
 
-The matchers temporarily disable `raise_on_detect` internally, so they work correctly regardless of your global configuration.
+Matchers capture a non-reporting scan: they never change global configuration, invoke callbacks, write findings, or raise `NPlus1Error`. Other concurrent scans retain their configured reporting and enforcement. Ignores and `enabled = false` still apply (disabled matchers execute the block but see no detections).
+
+Starting a matcher inside an already active scan raises `ArgumentError` **before executing its block**. Put the matcher around the request/job or scan instead; ordinary nested request/job scans still pass through to the matcher's scope. Both successful Minitest helpers count one assertion.
 
 ## Behavior by Environment
 

--- a/and_one.gemspec
+++ b/and_one.gemspec
@@ -21,12 +21,8 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ Gemfile .gitignore test/ .github/ .rubocop.yml])
-    end
+  spec.files = Dir.chdir(__dir__) do
+    Dir["lib/**/*.rb", "docs/**/*.md", "README.md", "CHANGELOG.md", "LICENSE.txt"]
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
+require "logger"
+require "active_record"
+require "rails/railtie"
+
 require_relative "and_one/version"
+require_relative "and_one/test_capture"
 require_relative "and_one/reporting"
 
 module AndOne
   class NPlus1Error < StandardError; end
 
   extend Reporting
+  extend TestCapture
 
   # Mutex for protecting lazy singleton initialization (aggregate, ignore_list)
   # and serializing report output so multi-line messages don't interleave
@@ -142,7 +148,7 @@ module AndOne
       end
     end
 
-    def finish_scan(owned_detector)
+    def finish_scan(owned_detector, reporting: true)
       return [] unless owned_detector && detector.equal?(owned_detector)
 
       begin
@@ -151,7 +157,7 @@ module AndOne
         release_scan(owned_detector)
       end
       detections = apply_ignore_filter(detections)
-      report(detections) if detections.any?
+      report(detections) if reporting && detections.any?
       detections
     end
 

--- a/lib/and_one/matchers.rb
+++ b/lib/and_one/matchers.rb
@@ -18,7 +18,7 @@ module AndOne
     def assert_no_n_plus_one(message = nil, &)
       detections = scan_for_n_plus_ones(&)
 
-      return unless detections.any?
+      return assert(true) if detections.empty?
 
       formatter = Formatter.new(
         backtrace_cleaner: AndOne.backtrace_cleaner || AndOne.send(:default_backtrace_cleaner)
@@ -40,25 +40,14 @@ module AndOne
         flunk(msg)
       end
 
+      assert(true)
       detections
     end
 
     private
 
     def scan_for_n_plus_ones(&)
-      # Temporarily disable raise_on_detect so scan returns detections
-      # instead of raising
-      previous_raise = AndOne.raise_on_detect
-      previous_callback = AndOne.notifications_callback
-      AndOne.raise_on_detect = false
-      AndOne.notifications_callback = nil
-
-      begin
-        AndOne.scan(&) || []
-      ensure
-        AndOne.raise_on_detect = previous_raise
-        AndOne.notifications_callback = previous_callback
-      end
+      AndOne.capture_for_test(&)
     end
   end
 
@@ -113,17 +102,7 @@ module AndOne
       private
 
       def scan_block(block)
-        previous_raise = AndOne.raise_on_detect
-        previous_callback = AndOne.notifications_callback
-        AndOne.raise_on_detect = false
-        AndOne.notifications_callback = nil
-
-        begin
-          AndOne.scan { block.call } || []
-        ensure
-          AndOne.raise_on_detect = previous_raise
-          AndOne.notifications_callback = previous_callback
-        end
+        AndOne.capture_for_test(&block)
       end
     end
   end

--- a/lib/and_one/rspec.rb
+++ b/lib/and_one/rspec.rb
@@ -11,10 +11,9 @@
 #   end
 #
 
+require "rspec/core"
 require "and_one"
 
-if defined?(RSpec)
-  RSpec.configure do |config|
-    config.include AndOne::RSpecHelper
-  end
+RSpec.configure do |config|
+  config.include AndOne::RSpecHelper
 end

--- a/lib/and_one/test_capture.rb
+++ b/lib/and_one/test_capture.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AndOne
+  # Internal, non-reporting scan scope for test integrations.
+  module TestCapture
+    def capture_for_test
+      raise ArgumentError, "AndOne matchers cannot run inside an active scan" if scanning?
+
+      unless enabled?
+        yield
+        return []
+      end
+
+      start_scan
+      owned_detector = detector
+      begin
+        yield
+        finish_scan(owned_detector, reporting: false)
+      ensure
+        release_scan(owned_detector)
+      end
+    end
+  end
+end

--- a/sig/and_one.rbs
+++ b/sig/and_one.rbs
@@ -1,4 +1,0 @@
-module AndOne
-  VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
-end

--- a/test/test_load_order.rb
+++ b/test/test_load_order.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class TestLoadOrder < Minitest::Test
+  LIB_PATH = File.expand_path("../lib", __dir__)
+  DATABASE_SETUP = <<~RUBY
+    require "active_record"
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+    ActiveRecord::Schema.define do
+      create_table(:parents) { |t| t.string :name }
+      create_table(:children) { |t| t.integer :parent_id }
+    end
+    class Parent < ActiveRecord::Base
+      has_many :children
+    end
+    class Child < ActiveRecord::Base
+      belongs_to :parent
+    end
+    3.times { Parent.create!.children.create! }
+    def load_children
+      Parent.all.map { |parent| parent.children.to_a }
+    end
+  RUBY
+
+  def run_ruby(source)
+    Dir.mktmpdir("and_one_smoke") do |root|
+      output, status = Open3.capture2e(
+        { "RAILS_ENV" => "test", "GITHUB_ACTIONS" => nil },
+        RbConfig.ruby, "-I", LIB_PATH, "-e", source, chdir: root
+      )
+      assert status.success?, output
+      output
+    end
+  end
+
+  def test_standalone_require
+    run_ruby('require "and_one"; abort "unexpected scan" if AndOne.scanning?')
+  end
+
+  def test_plain_active_record_scan
+    run_ruby(<<~RUBY)
+      require "and_one"
+      #{DATABASE_SETUP}
+      AndOne.raise_on_detect = false
+      detections = AndOne.scan { load_children }
+      abort "missing N+1" unless detections.any? { |d| d.table_name == "children" && d.count == 3 }
+      detections = AndOne.scan { Parent.preload(:children).map { |parent| parent.children.to_a } }
+      abort "preload flagged" unless detections.empty?
+    RUBY
+  end
+
+  def test_real_rails_boot_in_both_require_orders
+    [%w[rails/all and_one], %w[and_one rails/all]].each do |requires|
+      run_ruby(<<~RUBY)
+        #{requires.map { |name| "require #{name.inspect}" }.join("\n")}
+        class SmokeApp < Rails::Application
+          config.root = Dir.pwd
+          config.eager_load = false
+          config.secret_key_base = "test" * 32
+          config.logger = Logger.new(File::NULL)
+          config.active_support.deprecation = :stderr
+        end
+        Rails.application.initialize!
+        abort "disabled" unless AndOne.enabled?
+        abort "missing test default" unless AndOne.raise_on_detect
+        abort "missing middleware" unless Rails.application.middleware.any? { |m| m.klass == AndOne::Middleware }
+        abort "missing job hook" unless ActiveJob::Base < AndOne::ActiveJobHook
+      RUBY
+    end
+  end
+
+  def test_real_rspec_expectations_in_both_require_orders
+    [%w[rspec/core and_one/rspec], %w[and_one/rspec rspec/core]].each do |requires|
+      run_ruby(<<~RUBY)
+        #{requires.map { |name| "require #{name.inspect}" }.join("\n")}
+        #{DATABASE_SETUP}
+        AndOne.raise_on_detect = true
+        AndOne.notifications_callback = ->(*) { raise "matcher reported" }
+        RSpec.describe "AndOne integration" do
+          it("detects N+1") { expect { load_children }.to cause_n_plus_one }
+          it("accepts preload") do
+            expect { Parent.preload(:children).map { |p| p.children.to_a } }.not_to cause_n_plus_one
+          end
+          it "provides real positive and negative failure messages" do
+            expect { expect {}.to cause_n_plus_one }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /none were detected/)
+            expect { expect { load_children }.not_to cause_n_plus_one }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /children/)
+          end
+          it "rejects nesting" do
+            AndOne.scan do
+              expect { expect { nil }.not_to cause_n_plus_one }.to raise_error(ArgumentError, /active scan/)
+            end
+          end
+        end
+        exit RSpec::Core::Runner.run([])
+      RUBY
+    end
+  end
+end

--- a/test/test_matcher_isolation.rb
+++ b/test/test_matcher_isolation.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+
+class TestMatcherIsolation < Minitest::Test
+  include AndOneTestHelper
+  include AndOne::MinitestHelper
+  include AndOne::RSpecHelper
+
+  def repeated_queries
+    3.times do |index|
+      ActiveSupport::Notifications.instrument("sql.active_record", sql: "SELECT * FROM comments WHERE post_id = #{index}", name: "Comment Load")
+    end
+  end
+
+  def test_successful_helpers_count_assertions
+    before = assertions
+    assert_no_n_plus_one { nil }
+    assert_equal before + 1, assertions
+    before = assertions
+    assert_n_plus_one { repeated_queries }
+    assert_equal before + 1, assertions
+  end
+
+  def test_nested_matchers_reject_before_running_block_and_preserve_outer_scan
+    [nil, 42, []].each do |value|
+      AndOne.scan do
+        [->(&block) { assert_no_n_plus_one(&block) }, ->(&block) { cause_n_plus_one.matches?(block) }].each do |matcher|
+          called = false
+          error = assert_raises(ArgumentError) do
+            matcher.call do
+              called = true
+              value
+            end
+          end
+          assert_includes error.message, "inside an active scan"
+          refute called
+          assert AndOne.scanning?
+        end
+      end
+      refute AndOne.scanning?
+    end
+  end
+
+  def test_matcher_can_wrap_nested_application_scans
+    [nil, 42, []].each do |value|
+      assert_n_plus_one do
+        AndOne.scan do
+          repeated_queries
+          value
+        end
+      end
+      refute AndOne.scanning?
+    end
+  end
+
+  def test_nonlocal_exit_releases_the_matcher_scan
+    assert_equal :done, catch(:finished) {
+      assert_no_n_plus_one do
+        repeated_queries
+        throw :finished, :done
+      end
+    }
+    refute AndOne.scanning?
+    assert_no_n_plus_one { nil }
+  end
+
+  def test_disabled_matchers_execute_blocks_but_ignore_their_return_values
+    AndOne.enabled = false
+    [nil, 42, [Object.new]].each do |value|
+      called = false
+      assert_no_n_plus_one do
+        called = true
+        value
+      end
+      assert called
+      refute cause_n_plus_one.matches?(-> { value })
+    end
+  end
+
+  def test_matchers_apply_ignores_without_reporting_or_consuming_deduplication
+    AndOne.raise_on_detect = true
+    AndOne.notifications_callback = ->(*) { flunk "matcher must not report" }
+    assert_n_plus_one { repeated_queries }
+    assert_equal 0, AndOne.aggregate.size
+
+    AndOne.ignore_queries = [/comments/]
+    assert_no_n_plus_one { repeated_queries }
+    AndOne.ignore_queries = []
+    File.write(File.join(@aggregate_tmpdir, "ignore"), "query:comments\n")
+    AndOne.ignore_file_path = File.join(@aggregate_tmpdir, "ignore")
+    AndOne.reload_ignore_file!
+    refute cause_n_plus_one.matches?(-> { repeated_queries })
+  end
+
+  def test_settings_remain_unchanged_on_application_and_assertion_failures
+    callback = ->(*) { flunk "matcher must not report" }
+    AndOne.raise_on_detect = true
+    AndOne.notifications_callback = callback
+    assert_raises(RuntimeError) do
+      assert_no_n_plus_one do
+        assert AndOne.raise_on_detect
+        assert_same callback, AndOne.notifications_callback
+        raise "application failure"
+      end
+    end
+    assert_raises(Minitest::Assertion) { assert_no_n_plus_one { repeated_queries } }
+    assert AndOne.raise_on_detect
+    assert_same callback, AndOne.notifications_callback
+    refute AndOne.scanning?
+  end
+
+  def test_matcher_cannot_suppress_another_threads_enforcement_or_callback
+    entered = Queue.new
+    release = Queue.new
+    callbacks = Queue.new
+    AndOne.raise_on_detect = true
+    callback = ->(*) { callbacks << Thread.current }
+    AndOne.notifications_callback = callback
+    worker = Thread.new do
+      cause_n_plus_one.matches?(lambda do
+        entered << true
+        release.pop
+        repeated_queries
+      end)
+    end
+
+    Timeout.timeout(5) { entered.pop }
+    assert AndOne.raise_on_detect
+    assert_same callback, AndOne.notifications_callback
+    assert_raises(AndOne::NPlus1Error) { AndOne.scan { repeated_queries } }
+    assert_same Thread.current, Timeout.timeout(5) { callbacks.pop }
+    release << true
+    assert Timeout.timeout(5) { worker.value }
+    assert callbacks.empty?
+  ensure
+    release << true
+    worker&.kill
+    worker&.join
+  end
+end

--- a/test/test_matchers.rb
+++ b/test/test_matchers.rb
@@ -66,7 +66,7 @@ class TestMinitestHelper < Minitest::Test
 
   def test_matchers_dont_interfere_with_raise_on_detect
     # Even if raise_on_detect is true, matchers should work normally
-    # (they temporarily disable it internally)
+    # (their capture scope skips reporting without changing global settings)
     AndOne.raise_on_detect = true
 
     assert_no_n_plus_one do

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubygems/package"
+require "open3"
+require "rbconfig"
+
+class TestPackaging < Minitest::Test
+  def test_built_gem_contains_only_runtime_and_documentation_and_loads
+    root = File.expand_path("..", __dir__)
+    spec = Gem::Specification.load(File.join(root, "and_one.gemspec"))
+    Dir.mktmpdir("and_one_package") do |directory|
+      spec.files.each do |file|
+        destination = File.join(directory, file)
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.cp(File.join(root, file), destination)
+      end
+      capture_io { Dir.chdir(directory) { Gem::Package.build(spec) } }
+      package = Gem::Package.new(File.join(directory, spec.file_name))
+      assert_includes package.contents, "lib/and_one.rb"
+      assert_includes package.contents, "lib/and_one/test_capture.rb"
+      assert_includes package.contents, "README.md"
+      assert_includes package.contents, "LICENSE.txt"
+      assert_includes package.contents, "docs/sql-fingerprints.md"
+      assert(package.contents.all? { |file| file.match?(%r{\A(?:lib/.*\.rb|docs/.*\.md|README\.md|CHANGELOG\.md|LICENSE\.txt)\z}) })
+      installed = File.join(directory, "installed")
+      package.extract_files(installed)
+      output, status = Open3.capture2e(RbConfig.ruby, "-I", File.join(installed, "lib"), "-e", 'require "and_one"', chdir: directory)
+      assert status.success?, output
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Load required dependencies explicitly; support standalone ActiveRecord and Rails/RSpec require orders.
- Capture matcher findings without mutating global settings or consuming reporting/deduplication. Reject nested matchers before executing their blocks; preserve normal request/job nesting.
- Count successful Minitest assertions, document the integration boundaries, and package only runtime/docs files instead of development artifacts or placeholder RBS.

## Verification
- `bundle exec rake test`: 190 tests, 764 assertions, no failures/errors/skips.
- `bundle exec rubocop`: 55 files, no offenses.
- Subprocess tests cover standalone require, ActiveRecord N+1/preload, real Rails boots and RSpec expectations in both require orders, and loading an extracted built gem.
- Barrier-based concurrency regression verifies another scan still raises and invokes its callback while a matcher is active.

Closes #18
Closes #13