### PR TITLE
Fix association resolution and qualify optimization advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Resolve unambiguous belongs-to/has-one/has-many association directions and custom keys without retaining stale model caches; abstain on ambiguous/complex associations (#11).
+- Qualify preload advice, separate COUNT/EXISTS/scalar guidance, and label heuristic fix locations across text, JSON, dashboard, and GitHub annotations (#12).
 - Load runtime dependencies explicitly for standalone ActiveRecord use and register Rails/RSpec integrations safely in either require order (#18).
 - Keep test matcher capture scan-local without mutating global reporting settings; count successful Minitest assertions and reject matchers inside active scans with a clear error (#13).
 - Enforce `raise_on_detect` for every violating scan, independently of first-occurrence reporting and aggregate history (#2).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Detect N+1 queries in Rails applications with zero configuration and actionable fix suggestions.
 
-AndOne stays completely invisible until it detects an N+1 query — then it tells you exactly what's wrong and how to fix it. No external dependencies beyond Rails itself.
+AndOne stays completely invisible until it detects an N+1 query — then it points to repeated queries and suggests what to investigate. No external dependencies beyond Rails itself.
 
 ## Features
 
 - **Zero configuration** — Railtie auto-setup in development and test
-- **Actionable fix suggestions** — suggests the exact `.includes()`, `.preload()`, or `.eager_load()` call
-- **Smart location detection** — identifies both the origin (where the N+1 fires) and the fix location (where to add `.includes`)
+- **Qualified fix suggestions** — suggests candidate `.includes()`/`.preload()` calls for basic association record loading, with separate guidance for counts and scalar queries
+- **Location hints** — shows the origin and a heuristic caller location to investigate (not the proven relation-construction site)
 - **Clean error handling** — never corrupts backtraces or interferes with exception propagation
 - **No external dependencies** — only Rails itself
 - **Auto-raises in test** — N+1s fail your test suite by default
@@ -23,8 +23,16 @@ AndOne stays completely invisible until it detects an N+1 query — then it tell
 - **Per-environment thresholds** — different `min_n_queries` for development vs test
 - **GitHub Actions annotations** — N+1s appear as warning annotations on PR diffs
 - **`strict_loading` suggestions** — also suggests model-level prevention as an alternative
-- **`has_many :through` and polymorphic support** — resolves complex association chains
+- **Conservative association resolution** — handles unambiguous `belongs_to`, `has_one`, and `has_many`; abstains on complex or ambiguous SQL
 - **Thread-safe under Puma** — per-thread isolation verified with concurrent stress tests
+
+## Recommendation limits
+
+SQL alone does not prove which Ruby association was called. Association advice uses currently loaded models and qualified equality/`IN` predicates in plain, single-table SELECTs. Both foreign keys and `belongs_to` target primary keys (including custom single-column keys) are considered. Multiple matching associations/models, through associations, polymorphic associations, joins, aliases, CTEs, composite keys, and other complex SQL may receive only non-actionable guidance. Models and reflections are not cached: late-loaded models and Rails-reloaded classes are considered on the next resolution without retaining stale misses/classes.
+
+For basic record loading, try the suggested `includes` or `preload` on the parent relation and verify equivalent scopes/results and fewer queries. Filters or AND/OR tokens do **not** establish that a JOIN is faster. COUNT receives counter-cache/grouped-count guidance: `includes` alone does not eliminate association `.count` queries; `.size` can reuse an already loaded association when loading all its records is acceptable. Existence and scalar lookups receive batching guidance rather than an invented association fix. `strict_loading` hints apply to lazy record loading, not count/existence queries.
+
+The possible fix location is a **heuristic** caller frame, not necessarily where the relation was constructed. Text, dashboard, and GitHub annotations label it accordingly; JSON retains `fix_location` and adds `fix_location_confidence: "heuristic"`. JSON suggestions include `operation`, `association_type`, and `confidence` (`candidate` or `guidance_only`); guidance-only entries may have a null association/loading strategy.
 
 ## Installation
 
@@ -81,7 +89,7 @@ When an N+1 is detected, you get output like:
   Origin (where the N+1 is triggered):
   → app/views/posts/index.html.erb:5
 
-  Fix here (where to add .includes):
+  Possible fix location (heuristic; inspect the caller):
   ⇒ app/controllers/posts_controller.rb:8
 
   Call stack:
@@ -89,7 +97,7 @@ When an N+1 is detected, you get output like:
     app/controllers/posts_controller.rb:8
 
   💡 Suggestion:
-    Add `.includes(:comments)` to your Post query
+    If this is Post#comments record loading, try `.includes(:comments)` or `.preload(:comments)` on the parent query; verify scopes and results.
 
   To ignore, add to .and_one_ignore:
     fingerprint:a1b2c3d4e5f6
@@ -345,7 +353,7 @@ For manual `AndOne.scan` / `AndOne.finish` pairs, the caller must invoke `finish
 2. **Group** queries by call stack fingerprint
 3. **Fingerprint** SQL to detect same-shape queries with different bind values
 4. **Resolve** table names back to ActiveRecord models and associations
-5. **Suggest** the exact `.includes()` call to fix the N+1
+5. **Suggest** a candidate preload for basic record loading or operation-specific investigation guidance
 6. **Filter** against the `.and_one_ignore` file and aggregate tracker
 
 The middleware is designed to **never interfere with error propagation**. If your app raises an exception during a request, AndOne silently stops scanning and re-raises the original exception with its backtrace completely intact.

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -218,15 +218,6 @@ module AndOne
       end
     end
 
-    def suggest_association_name(detection)
-      suggestion = begin
-        AssociationResolver.resolve(detection, detection.raw_caller_strings)
-      rescue StandardError
-        nil
-      end
-      suggestion&.association_name || detection.table_name || "association"
-    end
-
     def resolve_ignore_file_path
       return ignore_file_path if ignore_file_path
 

--- a/lib/and_one/association_resolver.rb
+++ b/lib/and_one/association_resolver.rb
@@ -1,219 +1,91 @@
 # frozen_string_literal: true
 
+require_relative "query_evidence"
+require_relative "suggestion"
+
 module AndOne
-  # Resolves table names back to ActiveRecord models and identifies
-  # which association is being N+1 loaded, then suggests a fix.
+  # SQL provides candidates, not proof of which Ruby association was called.
   module AssociationResolver
     module_function
 
-    # Given a table name and a cleaned backtrace, attempt to identify
-    # the model, the parent association, and suggest an includes() fix.
     def resolve(detection, cleaned_backtrace)
-      table = detection.table_name
-      return nil unless table
+      evidence = QueryEvidence.new(detection.sample_query, adapter: detection.adapter)
+      target = model_for_table(detection.table_name)
+      return nil unless target
 
-      target_model = model_for_table(table)
-      return nil unless target_model
-
-      # Find the originating code location (first app frame in the backtrace)
-      origin_frame = find_origin_frame(cleaned_backtrace)
-
-      # Look for the parent model that has an association to the target
-      suggestion = find_association_suggestion(target_model, detection.sample_query)
-
+      candidates = evidence.operation == :records ? association_candidates(target, evidence) : []
+      parent, association = candidates.first if candidates.one?
       Suggestion.new(
-        target_model: target_model,
-        origin_frame: origin_frame,
-        association_name: suggestion&.dig(:association_name),
-        parent_model: suggestion&.dig(:parent_model),
-        fix_hint: suggestion&.dig(:fix_hint),
-        loading_strategy: suggestion&.dig(:loading_strategy),
-        is_through: suggestion&.dig(:is_through) || false,
-        is_polymorphic: suggestion&.dig(:is_polymorphic) || false
+        target_model: target, origin_frame: cleaned_backtrace&.first,
+        parent_model: parent, association_name: association&.name,
+        association_type: association&.macro, operation: evidence.operation,
+        loading_strategy: association && evidence.operation == :records ? :includes : nil,
+        fix_hint: recommendation(evidence.operation, parent, association)
       )
     end
 
-    # Maps table name -> AR model class.
-    # Thread-safe: uses a Mutex to protect the shared cache since multiple
-    # Puma threads may resolve associations concurrently.
+    # Deliberately uncached: misses must not survive lazy loading and classes or
+    # reflections must not survive a Rails reload. Ignore stale descendant objects
+    # whose constants have been removed/replaced by the reloader.
+    def models
+      ActiveRecord::Base.descendants.select do |klass|
+        klass.name && !klass.abstract_class? && klass.name.safe_constantize.equal?(klass)
+      end
+    end
+
     def model_for_table(table_name)
-      @table_model_mutex ||= Mutex.new
-      @table_model_cache ||= {}
+      return nil unless table_name
 
-      # Fast path: read from cache without lock (safe because we never delete keys,
-      # and Hash#[] under GVL is atomic for existing keys)
-      return @table_model_cache[table_name] if @table_model_cache.key?(table_name)
+      matches = models.select { |klass| klass.table_name == table_name }
+      matches.first if matches.one?
+    end
 
-      @table_model_mutex.synchronize do
-        # Double-check after acquiring lock
-        return @table_model_cache[table_name] if @table_model_cache.key?(table_name)
+    def association_candidates(target, evidence)
+      return [] unless evidence.simple?
 
-        model = ActiveRecord::Base.descendants.detect do |klass|
-          klass.table_name == table_name
-        rescue StandardError
-          false
+      models.flat_map do |parent|
+        parent.reflect_on_all_associations.filter_map do |association|
+          [parent, association] if association_matches?(association, target, evidence)
         end
-
-        @table_model_cache[table_name] = model
-        model
       end
     end
 
-    # Finds the first backtrace frame that's in the app (not a gem/framework frame)
-    def find_origin_frame(cleaned_backtrace)
-      cleaned_backtrace&.first
-    end
+    def association_matches?(association, target, evidence)
+      return false unless %i[belongs_to has_one has_many].include?(association.macro)
+      return false if association.is_a?(ActiveRecord::Reflection::ThroughReflection)
+      return false if association.polymorphic? || association.options[:as]
+      return false unless association.klass == target
 
-    # Tries to find which association on a parent model points to the target model,
-    # and extracts hints from the WHERE clause about the foreign key.
-    def find_association_suggestion(target_model, sql)
-      # Extract the foreign key column from WHERE clause
-      # e.g., WHERE "comments"."post_id" = ? or WHERE "comments"."post_id" IN (?)
-      foreign_key = extract_foreign_key(sql, target_model.table_name)
+      key = if association.macro == :belongs_to
+              association.association_primary_key
+            else
+              association.foreign_key
+            end
+      return false if key.is_a?(Array)
 
-      # Also try polymorphic foreign key pattern (e.g., commentable_id)
-      poly_foreign_key = extract_polymorphic_foreign_key(sql, target_model.table_name) unless foreign_key
-
-      effective_key = foreign_key || poly_foreign_key
-
-      # Search all models for an association whose foreign key matches
-      ActiveRecord::Base.descendants.each do |klass|
-        next if klass.abstract_class?
-
-        klass.reflect_on_all_associations.each do |assoc|
-          matched = if effective_key
-                      association_matches?(assoc, target_model, effective_key)
-                    else
-                      # For through associations, foreign key may not be directly visible
-                      through_association_matches?(assoc, target_model)
-                    end
-
-          next unless matched
-
-          strategy = loading_strategy(sql, assoc.name)
-
-          return {
-            parent_model: klass,
-            association_name: assoc.name,
-            fix_hint: build_fix_hint(klass, assoc.name),
-            loading_strategy: strategy,
-            is_through: assoc.is_a?(ActiveRecord::Reflection::ThroughReflection),
-            is_polymorphic: assoc.respond_to?(:options) && !assoc.options[:as].nil?
-          }
-        end
-      rescue StandardError
-        next
-      end
-
-      nil
-    end
-
-    def through_association_matches?(assoc, target_model)
-      return false unless assoc.is_a?(ActiveRecord::Reflection::ThroughReflection)
-
-      begin
-        assoc.klass == target_model
-      rescue NameError
-        false
-      end
-    end
-
-    def extract_polymorphic_foreign_key(sql, table_name)
-      # Match patterns like: "table"."something_type" = AND "table"."something_id"
-      pattern = /["`]?#{Regexp.escape(table_name)}["`]?\.["`]?(\w+)_type["`]?\s*=/i
-      match = sql.match(pattern)
-      "#{match.captures.first}_id" if match
-    end
-
-    def extract_foreign_key(sql, table_name)
-      # Match patterns like: "table"."column_id" = or "table"."column_id" IN
-      pattern = /["`]?#{Regexp.escape(table_name)}["`]?\.["`]?(\w+_id)["`]?\s*(?:=|IN)/i
-      match = sql.match(pattern)
-      match&.captures&.first
-    end
-
-    def association_matches?(assoc, target_model, foreign_key)
-      case assoc
-      when ActiveRecord::Reflection::ThroughReflection
-        # has_many :through — check if the source association points to our target
-        assoc.klass == target_model
-      when ActiveRecord::Reflection::HasManyReflection,
-           ActiveRecord::Reflection::HasOneReflection
-        if assoc.options[:as]
-          # Polymorphic: has_many :comments, as: :commentable
-          # The foreign key is like "commentable_id" and there's a "commentable_type" column
-          poly_fk = "#{assoc.options[:as]}_id"
-          assoc.klass == target_model && poly_fk == foreign_key
-        else
-          assoc.klass == target_model && assoc.foreign_key.to_s == foreign_key
-        end
-      else
-        false
-      end
+      evidence.predicate_columns(target.table_name).include?(key.to_s)
     rescue NameError
       false
     end
 
-    def build_fix_hint(parent_model, association_name)
-      "Add `.includes(:#{association_name})` to your #{parent_model.name} query"
-    end
-
-    # Determine the optimal loading strategy based on query patterns
-    def loading_strategy(sql, _association_name)
-      # If the query has WHERE conditions on the association table, eager_load
-      # is better because it does a LEFT OUTER JOIN allowing WHERE filtering
-      if sql =~ /\bWHERE\b/i && (sql =~ /\bJOIN\b/i || sql =~ /\b(?:AND|OR)\b/i)
-        :eager_load
+    def recommendation(operation, parent, association)
+      case operation
+      when :count
+        "For COUNT, consider a counter cache or grouped counts; use .size only on an already loaded association " \
+        "when loading all records is acceptable. includes alone does not eliminate .count queries."
+      when :exists
+        "For existence checks, consider batching matching keys; verify equivalent scope and NULL semantics."
+      when :scalar
+        "For scalar lookups, consider a grouped/batched query; SQL alone cannot identify an association fix."
+      when :records
+        if association
+          "If this is #{parent.name}##{association.name} record loading, try `.includes(:#{association.name})` " \
+            "or `.preload(:#{association.name})` on the parent query; verify scopes and results."
+        else
+          "Association is ambiguous or unsupported from SQL alone; inspect the call site before choosing a preload."
+        end
       else
-        # Default: preload is generally faster (separate queries, no JOIN overhead)
-        # includes is the safe default that lets Rails choose
-        :includes
-      end
-    end
-  end
-
-  class Suggestion
-    attr_reader :target_model, :origin_frame, :association_name, :parent_model,
-                :fix_hint, :loading_strategy, :is_through, :is_polymorphic
-
-    def initialize(target_model:, origin_frame:, association_name:, parent_model:,
-                   fix_hint:, loading_strategy: nil, is_through: false, is_polymorphic: false)
-      @target_model = target_model
-      @origin_frame = origin_frame
-      @association_name = association_name
-      @parent_model = parent_model
-      @fix_hint = fix_hint
-      @loading_strategy = loading_strategy
-      @is_through = is_through
-      @is_polymorphic = is_polymorphic
-    end
-
-    def actionable?
-      !!@association_name
-    end
-
-    # Suggest strict_loading as an alternative prevention strategy
-    def strict_loading_hint
-      return nil unless actionable? && @parent_model
-
-      assoc_type = if @is_through
-                     "has_many :#{@association_name}, through: ..."
-                   else
-                     "has_many :#{@association_name}"
-                   end
-
-      "Or prevent at the model level: `#{assoc_type}, strict_loading: true` in #{@parent_model.name}"
-    end
-
-    # Suggest the optimal loading strategy when it differs from plain .includes
-    def loading_strategy_hint
-      return nil unless actionable? && @loading_strategy
-
-      case @loading_strategy
-      when :eager_load
-        "Consider `.eager_load(:#{@association_name})` instead — your query filters on the association, so a JOIN is more efficient"
-      when :preload
-        "Consider `.preload(:#{@association_name})` — separate queries avoid JOIN overhead for simple loading"
+        "Cannot infer a safe association fix from this SQL; inspect the call site."
       end
     end
   end

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -48,7 +48,7 @@ module AndOne
     end
 
     # The frame where the AR relation/collection was likely loaded or iterated.
-    # This is the best place to add .includes().
+    # Heuristic only: the stack does not identify where a relation was built.
     def fix_location
       @fix_location ||= find_fix_location
     end

--- a/lib/and_one/dev_ui.rb
+++ b/lib/and_one/dev_ui.rb
@@ -50,7 +50,7 @@ module AndOne
                  rescue StandardError
                    nil
                  end
-                 fix = suggestion&.actionable? ? h(suggestion.fix_hint) : "—"
+                 fix = suggestion&.fix_hint ? h(suggestion.fix_hint) : "—"
                  strict_hint = suggestion&.strict_loading_hint ? h(suggestion.strict_loading_hint) : ""
                  loading_hint = suggestion&.loading_strategy_hint ? h(suggestion.loading_strategy_hint) : ""
 
@@ -65,7 +65,7 @@ module AndOne
                      <td><code class="sql">#{h(truncate(det.sample_query, 200))}</code></td>
                      <td>
                        <div class="origin">#{h(origin)}</div>
-                       <div class="fix-loc">⇒ #{h(fix_loc)}</div>
+                       <div class="fix-loc">Possible fix location (heuristic): #{h(fix_loc)}</div>
                      </td>
                      <td>
                        <div class="suggestion">#{fix}</div>
@@ -123,7 +123,7 @@ module AndOne
                 <th>Count</th>
                 <th>Query</th>
                 <th>Location</th>
-                <th>Fix</th>
+                <th>Suggested investigation</th>
               </tr>
             </thead>
             <tbody>

--- a/lib/and_one/formatter.rb
+++ b/lib/and_one/formatter.rb
@@ -61,9 +61,9 @@ module AndOne
         lines << ""
       end
 
-      # Fix location — where to add .includes
+      # The stack supplies a heuristic investigation location, not relation provenance.
       if detection.fix_location && detection.fix_location != detection.origin_frame
-        lines << colorize("  Fix here (where to add .includes):", :cyan)
+        lines << colorize("  Possible fix location (heuristic; inspect the caller):", :cyan)
         lines << colorize("  ⇒ #{format_frame(detection.fix_location)}", :green)
         lines << ""
       end
@@ -78,7 +78,7 @@ module AndOne
 
       # Association suggestion
       suggestion = resolve_suggestion(detection, cleaned_bt)
-      if suggestion&.actionable?
+      if suggestion&.fix_hint
         lines << colorize("  💡 Suggestion:", :cyan, :bold)
         lines << colorize("    #{suggestion.fix_hint}", :green)
         lines << colorize("    #{suggestion.loading_strategy_hint}", :green) if suggestion.loading_strategy_hint

--- a/lib/and_one/json_formatter.rb
+++ b/lib/and_one/json_formatter.rb
@@ -52,12 +52,16 @@ module AndOne
         sample_query: detection.sample_query,
         origin: format_frame(detection.origin_frame),
         fix_location: format_frame(detection.fix_location),
+        fix_location_confidence: detection.fix_location ? "heuristic" : nil,
         backtrace: clean_backtrace(detection.raw_caller_strings).first(10)
       }
 
-      if suggestion&.actionable?
+      if suggestion&.fix_hint
         entry[:suggestion] = {
-          association: suggestion.association_name.to_s,
+          association: suggestion.association_name&.to_s,
+          association_type: suggestion.association_type&.to_s,
+          operation: suggestion.operation.to_s,
+          confidence: suggestion.actionable? ? "candidate" : "guidance_only",
           parent_model: suggestion.parent_model&.name,
           fix: suggestion.fix_hint,
           loading_strategy: suggestion.loading_strategy&.to_s

--- a/lib/and_one/query_evidence.rb
+++ b/lib/and_one/query_evidence.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "sql_lexer"
+
+module AndOne
+  # Conservative evidence for advice, not a general SQL classifier. Only plain
+  # single-table SELECTs with qualified equality/IN predicates support resolution.
+  class QueryEvidence
+    def initialize(sql, adapter: nil)
+      @tokens = SqlLexer.new(sql, adapter: adapter).tokens
+    end
+
+    def operation
+      return :unknown unless word?(@tokens.first, "select")
+
+      projection = @tokens[1...from_index]
+      return :count if word?(projection.first, "count") && projection[1]&.text == "("
+      return :exists if word?(projection.first, "exists") || projection.any? { |token| identifier(token) == "one" }
+      return :records if projection.map(&:text) == ["*"] || record_projection?(projection)
+
+      :scalar
+    end
+
+    def simple?
+      from_index && word?(@tokens.first, "select") &&
+        @tokens.none? { |token| token.kind == :opaque || (token.kind == :word && %w[join union intersect except or].include?(token.text)) } &&
+        @tokens.one? { |token| word?(token, "select") } && single_table?
+    end
+
+    def predicate_columns(table)
+      where = @tokens.index { |token| word?(token, "where") }
+      return [] unless where
+
+      @tokens[(where + 1)..].each_cons(4).filter_map do |owner, dot, column, operator|
+        next unless identifier(owner) == table && dot.text == "."
+        next unless operator.text == "=" || word?(operator, "in")
+
+        identifier(column)
+      end
+    end
+
+    private
+
+    def from_index
+      @from_index ||= @tokens.index { |token| word?(token, "from") }
+    end
+
+    def single_table?
+      tail = @tokens[(from_index + 1)..]
+      boundary = tail.index { |token| token.kind == :word && %w[where limit order group having offset].include?(token.text) }
+      source = boundary ? tail.first(boundary) : tail
+      source = source.reject { |token| token.text == ";" }
+      source.one? && identifier(source.first)
+    end
+
+    def record_projection?(projection)
+      projection.size == 3 && identifier(projection[0]) && projection[1].text == "." && projection[2].text == "*"
+    end
+
+    def word?(token, text)
+      token&.kind == :word && token.text == text
+    end
+
+    def identifier(token)
+      return token.text if token&.kind == :word
+      return unless token&.kind == :identifier
+
+      token.text[1...-1]
+    end
+  end
+end

--- a/lib/and_one/reporting.rb
+++ b/lib/and_one/reporting.rb
@@ -39,12 +39,18 @@ module AndOne
       end
     end
 
+    def annotation_hint(detection)
+      AssociationResolver.resolve(detection, detection.raw_caller_strings)&.fix_hint || "Inspect the call site."
+    rescue StandardError
+      "Inspect the call site."
+    end
+
     def report_annotations(detections)
       detections.each do |detection|
         file, line = parse_frame_location(detection.fix_location || detection.origin_frame)
         query_count = "#{detection.count} queries to `#{detection.table_name || "unknown"}`"
         if file
-          hint = "Add `.includes(:#{suggest_association_name(detection)})` to fix."
+          hint = "Possible fix location (heuristic). #{annotation_hint(detection)}"
           $stdout.puts "::warning file=#{file},line=#{line || 1}::N+1 detected: #{query_count}. #{hint}"
         else
           $stdout.puts "::warning ::N+1 detected: #{query_count}."

--- a/lib/and_one/suggestion.rb
+++ b/lib/and_one/suggestion.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module AndOne
+  class Suggestion
+    attr_reader :target_model, :origin_frame, :association_name, :parent_model,
+                :fix_hint, :loading_strategy, :is_through, :is_polymorphic,
+                :association_type, :operation
+
+    def initialize(target_model:, origin_frame:, association_name:, parent_model:,
+                   fix_hint:, loading_strategy: nil, **evidence)
+      @target_model = target_model
+      @origin_frame = origin_frame
+      @association_name = association_name
+      @parent_model = parent_model
+      @fix_hint = fix_hint
+      @loading_strategy = loading_strategy
+      @is_through = evidence.fetch(:is_through, false)
+      @is_polymorphic = evidence.fetch(:is_polymorphic, false)
+      reflection = parent_model&.reflect_on_association(association_name) if association_name
+      @association_type = evidence[:association_type] || reflection&.macro
+      @operation = evidence.fetch(:operation, :records)
+    end
+
+    def actionable?
+      !!@association_name && @operation == :records
+    end
+
+    def strict_loading_hint
+      return nil unless actionable? && @parent_model && @association_type
+
+      declaration = "#{@association_type} :#{@association_name}"
+      declaration += ", through: ..." if @is_through
+      "Or prevent lazy record loading: `#{declaration}, strict_loading: true` in #{@parent_model.name}"
+    end
+
+    def loading_strategy_hint
+      return nil unless actionable?
+
+      case @loading_strategy
+      when :eager_load
+        "Consider `.eager_load(:#{@association_name})` only if JOIN semantics are needed; verify results and query cost"
+      when :preload
+        "Consider `.preload(:#{@association_name})` for separate-query record loading; verify scopes and results"
+      end
+    end
+  end
+end

--- a/test/test_association_evidence.rb
+++ b/test/test_association_evidence.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "zeitwerk"
+
+class TestAssociationEvidence < Minitest::Test
+  include AndOneTestHelper
+
+  def setup
+    super
+    @constants = []
+    connection = ActiveRecord::Base.connection
+    connection.create_table(:advice_owners, force: true) { |t| t.string :code }
+    connection.create_table(:advice_items, force: true) { |t| t.string :owner_code }
+    connection.create_table(:advice_badges, force: true) { |t| t.integer :advice_owner_id }
+    connection.create_table(:advice_notes, force: true) do |t|
+      t.integer :notable_id
+      t.string :notable_type
+    end
+    model(:AdviceOwner)
+    model(:AdviceItem)
+    model(:AdviceBadge)
+    model(:AdviceNote)
+    AdviceOwner.has_many :items, class_name: "AdviceItem", foreign_key: :owner_code, primary_key: :code
+    AdviceItem.belongs_to :owner, class_name: "AdviceOwner", foreign_key: :owner_code, primary_key: :code
+    AdviceOwner.has_one :badge, class_name: "AdviceBadge"
+    AdviceBadge.belongs_to :advice_owner
+    AdviceOwner.has_many :notes, as: :notable, class_name: "AdviceNote"
+    AdviceNote.belongs_to :notable, polymorphic: true
+    AdviceItem.has_many :notes, through: :owner
+    AdviceItem.has_one :badge, through: :owner
+    3.times do |i|
+      owner = AdviceOwner.create!(code: "owner-#{i}")
+      owner.items.create!
+      owner.create_badge!
+      owner.notes.create!
+    end
+  end
+
+  def teardown
+    @constants.each { |name| Object.send(:remove_const, name) if Object.const_defined?(name, false) }
+    super
+  end
+
+  def test_belongs_to_direction
+    suggestion = resolve('SELECT "authors".* FROM "authors" WHERE "authors"."id" = 1 LIMIT 1')
+
+    assert_equal Post, suggestion.parent_model
+    assert_equal :author, suggestion.association_name
+    assert_includes suggestion.strict_loading_hint, "belongs_to :author"
+  end
+
+  def test_custom_keys_in_both_directions
+    suggestion = scan_suggestion { AdviceOwner.all.each { |owner| owner.items.to_a } }
+    assert_equal :items, suggestion.association_name
+    assert_includes suggestion.strict_loading_hint, "has_many :items"
+
+    suggestion = scan_suggestion { AdviceItem.all.each(&:owner) }
+    assert_equal :owner, suggestion.association_name
+    assert_includes suggestion.strict_loading_hint, "belongs_to :owner"
+  end
+
+  def test_has_one_declaration
+    suggestion = scan_suggestion { AdviceOwner.all.each(&:badge) }
+    assert_equal :badge, suggestion.association_name
+    assert_includes suggestion.strict_loading_hint, "has_one :badge"
+  end
+
+  def test_two_associations_abstain
+    AdviceOwner.has_many :other_items, class_name: "AdviceItem", foreign_key: :owner_code, primary_key: :code
+    suggestion = scan_suggestion { AdviceOwner.all.each { |owner| owner.items.to_a } }
+
+    refute suggestion.actionable?
+    assert_nil suggestion.association_name
+    assert_includes suggestion.fix_hint, "ambiguous"
+  end
+
+  def test_polymorphic_and_through_queries_abstain
+    suggestion = scan_suggestion { AdviceOwner.all.each { |owner| owner.notes.to_a } }
+    refute suggestion.actionable?
+    suggestion = scan_suggestion { AdviceItem.all.each { |item| item.notes.to_a } }
+    refute suggestion.actionable?
+    suggestion = scan_suggestion { AdviceItem.all.each(&:badge) }
+    refute suggestion.actionable?
+  end
+
+  def test_misses_are_not_cached_and_reloaded_classes_are_not_retained
+    assert_nil AndOne::AssociationResolver.model_for_table("advice_late_models")
+    original = model(:AdviceLateModel)
+    assert_same original, AndOne::AssociationResolver.model_for_table("advice_late_models")
+    Object.send(:remove_const, :AdviceLateModel)
+    replacement = model(:AdviceLateModel)
+    refute_same original, replacement
+    assert_same replacement, AndOne::AssociationResolver.model_for_table("advice_late_models")
+  end
+
+  def test_zeitwerk_reload_replaces_resolved_classes
+    Dir.mktmpdir("and_one_reload") do |directory|
+      File.write(File.join(directory, "advice_reloaded.rb"), "class AdviceReloaded < ActiveRecord::Base; end")
+      loader = Zeitwerk::Loader.new
+      loader.push_dir(directory)
+      loader.enable_reloading
+      loader.setup
+      original = AdviceReloaded
+      assert_same original, AndOne::AssociationResolver.model_for_table("advice_reloadeds")
+      loader.reload
+      replacement = AdviceReloaded
+      refute_same original, replacement
+      assert_same replacement, AndOne::AssociationResolver.model_for_table("advice_reloadeds")
+    ensure
+      loader&.unload
+      loader&.unregister
+    end
+  end
+
+  def test_reflections_are_not_cached
+    suggestion = scan_suggestion { AdviceOwner.all.each(&:badge) }
+    assert_equal :badge, suggestion.association_name
+    AdviceOwner.has_one :other_badge, class_name: "AdviceBadge"
+    refute scan_suggestion { AdviceOwner.all.each(&:badge) }.actionable?
+  end
+
+  private
+
+  def model(name)
+    @constants << name unless @constants.include?(name)
+    Object.const_set(name, Class.new(ActiveRecord::Base))
+  end
+
+  def resolve(sql)
+    detection = AndOne::Detection.new(queries: [sql], count: 3, adapter: "SQLite")
+    AndOne::AssociationResolver.resolve(detection, [])
+  end
+
+  def scan_suggestion(&)
+    detections = AndOne.scan(&)
+    refute_empty detections
+    AndOne::AssociationResolver.resolve(detections.first, [])
+  end
+end

--- a/test/test_recommendations.rb
+++ b/test/test_recommendations.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestRecommendations < Minitest::Test
+  include AndOneTestHelper
+
+  def setup
+    super
+    seed_data!
+  end
+
+  def teardown
+    Comment.delete_all
+    Post.delete_all
+    Author.delete_all
+    super
+  end
+
+  def test_record_loading_advice_reduces_queries_with_equivalent_results
+    %i[includes preload].each do |strategy|
+      suggestion = resolve(scan { Post.all.each { |post| post.comments.to_a } })
+      assert_equal :comments, suggestion.association_name
+      assert_includes suggestion.fix_hint, ".#{strategy}(:comments)"
+      baseline, before = measure { Post.all.map { |post| post.comments.map(&:id) } }
+      fixed, after = measure { Post.public_send(strategy, :comments).map { |post| post.comments.map(&:id) } }
+      assert_equal baseline, fixed
+      assert_operator after, :<, before
+      assert_equal 2, after
+    end
+  end
+
+  def test_belongs_to_and_has_many_advice_preserve_results
+    %i[includes preload].each do |strategy|
+      suggestion = resolve(scan { Post.all.each(&:author) })
+      assert_equal :author, suggestion.association_name
+      assert_includes suggestion.fix_hint, ".#{strategy}(:author)"
+      baseline, before = measure { Post.all.map { |post| post.author.name } }
+      fixed, after = measure { Post.public_send(strategy, :author).map { |post| post.author.name } }
+      assert_equal baseline, fixed
+      assert_operator after, :<, before
+      assert_equal 2, after
+    end
+  end
+
+  def test_count_advice_is_not_an_includes_fix
+    detection = scan { Post.all.each { |post| post.comments.count } }
+    suggestion = resolve(detection)
+    assert_equal :count, suggestion.operation
+    refute suggestion.actionable?
+    assert_nil suggestion.loading_strategy
+    assert_nil suggestion.strict_loading_hint
+    assert_includes suggestion.fix_hint, "counter cache"
+    assert_includes suggestion.fix_hint, "includes alone does not eliminate .count"
+
+    counts, before = measure { Post.all.map { |post| post.comments.count } }
+    loaded_counts, after = measure { Post.preload(:comments).map { |post| post.comments.size } }
+    assert_equal counts, loaded_counts
+    assert_operator after, :<, before
+  end
+
+  def test_exists_and_scalar_queries_do_not_invent_association_fixes
+    exists = resolve(scan { Post.all.each { |post| post.comments.exists? } })
+    scalar = resolve(scan { Post.all.each { |post| post.comments.pluck(:body) } })
+    assert_equal :exists, exists.operation
+    assert_equal :scalar, scalar.operation
+    [exists, scalar].each do |suggestion|
+      refute suggestion.actionable?
+      assert_nil suggestion.association_name
+      assert_nil suggestion.loading_strategy
+      refute_includes suggestion.fix_hint, ".includes"
+    end
+  end
+
+  def test_and_or_and_join_do_not_imply_join_efficiency
+    ["AND comments.body = 'hello'", "OR comments.body = 'hello'"].each do |condition|
+      detection = detection_for("SELECT comments.* FROM comments WHERE comments.post_id = 1 #{condition}")
+      suggestion = resolve(detection)
+      refute_equal :eager_load, suggestion.loading_strategy
+      refute_includes suggestion.fix_hint, "more efficient"
+    end
+    suggestion = resolve(detection_for("SELECT comments.* FROM comments JOIN posts ON posts.id = comments.post_id"))
+    refute suggestion.actionable?
+  end
+
+  def test_lexer_ignores_keywords_in_literals_and_comments
+    suggestion = resolve(detection_for("SELECT comments.* FROM comments WHERE comments.post_id = 1 AND comments.body = 'COUNT EXISTS JOIN' /* OR */"))
+    assert_equal :records, suggestion.operation
+    assert_equal :comments, suggestion.association_name
+    assert_equal :includes, suggestion.loading_strategy
+  end
+
+  def test_all_outputs_qualify_locations_and_show_count_guidance
+    detection = detection_for("SELECT COUNT(*) FROM comments WHERE comments.post_id = 1")
+    text = AndOne::Formatter.new.format([detection])
+    assert_includes text, "Possible fix location (heuristic"
+    assert_includes text, "counter cache"
+    refute_includes text, "Fix here"
+
+    json = AndOne::JsonFormatter.new.format_hashes([detection]).first
+    assert_equal "heuristic", json[:fix_location_confidence]
+    assert_equal "count", json[:suggestion][:operation]
+    assert_equal "guidance_only", json[:suggestion][:confidence]
+
+    AndOne.aggregate.record(detection)
+    _, _, body = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one")
+    assert_includes body.join, "Possible fix location (heuristic)"
+    assert_includes body.join, "counter cache"
+
+    output, = capture_io { AndOne.send(:report_annotations, [detection]) }
+    assert_includes output, "Possible fix location (heuristic)"
+    assert_includes output, "counter cache"
+    refute_includes output, "to fix."
+  end
+
+  private
+
+  def scan(&)
+    detections = AndOne.scan(&)
+    refute_empty detections
+    detections.first
+  end
+
+  def resolve(detection)
+    AndOne::AssociationResolver.resolve(detection, detection.raw_caller_strings)
+  end
+
+  def detection_for(sql)
+    AndOne::Detection.new(queries: [sql], count: 3, adapter: "SQLite",
+                          raw_caller_strings: ["app/models/post.rb:10:in 'comments'", "app/controllers/posts_controller.rb:20:in 'index'"])
+  end
+
+  def measure(&block)
+    count = 0
+    subscriber = lambda do |*args|
+      payload = args.last
+      count += 1 unless payload[:cached] || payload[:name] == "SCHEMA"
+    end
+    result = ActiveRecord::Base.uncached do
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record", &block)
+    end
+    [result, count]
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #11
Fixes #12

These related issues share the recommendation path, so this PR fixes association evidence and its output together.

- Resolve unambiguous belongs_to, has_one, and has_many associations in the correct direction, including custom single-column keys; preserve the declaration type in strict-loading hints.
- Abstain on ambiguous or unsupported associations instead of selecting the first reflection. Use conservative lexical evidence for plain single-table queries.
- Remove the model cache rather than adding reload-hook invalidation: no negative cache survives lazy loading, and stale descendant classes are excluded after reload. This trades cached lookup speed for fresh model/reflection evidence; no Railtie lifecycle changes are needed.
- Separate record-loading recommendations from COUNT, EXISTS, and scalar guidance; remove unsupported JOIN-efficiency claims.
- Qualify caller locations as heuristic across text, JSON, dashboard, and GitHub annotations. Document supported cases, limitations, and additive JSON metadata.

## Validation
- `bundle exec rake test`: 205 runs, 900 assertions, no failures/errors/skips.
- `bundle exec rubocop`: 59 files, no offenses.
- `git diff --cached --check`: passed before commit.
- Added real SQLite association fixtures for custom keys, has-one, through, and polymorphic cases; ambiguity, late loading, reflection changes, and real Zeitwerk reload regressions.
- Integration tests apply includes/preload to belongs-to and has-many loading and verify fewer physical queries with equivalent results. COUNT-to-loaded-size behavior and all advice output surfaces are covered.

## Scope
No query detection/grouping, storage lifecycle, async behavior, or general SQL-parser changes. Through/polymorphic inference remains explicitly unsupported rather than advertised as exact.