### PR TITLE
Bound SQL capture and define fiber/async scan boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AndOne stays completely invisible until it detects an N+1 query — then it poin
 - **GitHub Actions annotations** — N+1s appear as warning annotations on PR diffs
 - **`strict_loading` suggestions** — also suggests model-level prevention as an alternative
 - **Conservative association resolution** — handles unambiguous `belongs_to`, `has_one`, and `has_many`; abstains on complex or ambiguous SQL
-- **Thread-safe under Puma** — per-thread isolation verified with concurrent stress tests
+- **Isolated capture** — one SQL subscriber, fiber-local scans, and bounded representative query samples; verified with concurrent stress tests
 
 ## Recommendation limits
 
@@ -70,6 +70,14 @@ puts "Detected #{detections.size} repeated-query patterns"
 ```
 
 Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans persist findings under `tmp/and_one` by default; set `aggregate_path` before the first scan to change it. `require "and_one"` is safe before or after loading Rails.
+
+## Capture coverage and limits
+
+Scans capture synchronous ActiveRecord SQL in the **current fiber**. Child fibers/threads do not inherit scans; start independent scans inside them if needed. Async-tagged SQL is excluded because Rails may publish worker notifications later in an unrelated consumer's scan. Synchronous `load_async` fallback is captured normally. Lazy response-body SQL is outside request scan coverage.
+
+One process-level subscriber routes events to the active context. Each repeated shape/location retains its first five SQL samples plus an exact total count: `Detection#queries` is a sample, while `Detection#count` includes all eligible occurrences. Query-ignore rules still inspect every occurrence. Unique groups and individual SQL sizes are not capped.
+
+See [capture boundaries, retention, and benchmark commands](docs/capture.md) for details.
 
 ## What You'll See
 

--- a/bench/capture.rb
+++ b/bench/capture.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Synthetic notification benchmark: no DB latency, reporting, or persistence.
+# Run with: bundle exec ruby bench/capture.rb
+require "json"
+require_relative "../lib/and_one"
+
+module CaptureBenchmark
+  module_function
+
+  def clock
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def emit(queries, mode)
+    queries.times do |i|
+      table = mode == :active_clean ? "items_#{i}" : "items"
+      ActiveSupport::Notifications.instrument("sql.active_record", name: "Load", sql: "SELECT * FROM #{table} WHERE id = #{i}")
+    end
+  end
+
+  def workload(mode, queries)
+    retained = [0, 0]
+    AndOne.capture_for_test do
+      emit(queries, mode)
+      detector = AndOne::ExecutionContext.active_detector
+      if detector
+        # Inspect internal storage, including clean groups that produce no finding.
+        samples = detector.instance_variable_get(:@groups).values.flat_map(&:queries)
+        retained = [samples.size, samples.sum(&:bytesize)]
+      end
+    end
+    retained
+  end
+
+  def run_scans(mode, scans, queries)
+    latencies = []
+    peak = [0, 0]
+    scans.times do
+      began = clock
+      samples, bytes = workload(mode, queries)
+      latencies << ((clock - began) * 1000)
+      peak = [[peak[0], samples].max, [peak[1], bytes].max]
+    end
+    [latencies, peak]
+  end
+
+  def measure(mode, concurrency, scans, queries)
+    AndOne.enabled = mode != :disabled
+    ready = Queue.new
+    start = Queue.new
+    workers = Array.new(concurrency) do
+      Thread.new do
+        ready << true
+        start.pop
+        run_scans(mode, scans, queries)
+      end
+    end
+    concurrency.times { ready.pop }
+    GC.start
+    allocated = GC.stat(:total_allocated_objects)
+    began = clock
+    concurrency.times { start << true }
+    results = workers.map(&:value)
+    elapsed = clock - began
+    allocations = GC.stat(:total_allocated_objects) - allocated
+    latencies = results.flat_map(&:first)
+    {
+      mode: mode, concurrency: concurrency, scans_per_thread: scans, queries_per_scan: queries,
+      elapsed_seconds: elapsed, notifications_per_second: concurrency * scans * queries / elapsed,
+      allocated_objects: allocations, allocations_per_notification: allocations.fdiv(concurrency * scans * queries),
+      scan_latency_ms: { mean: latencies.sum / latencies.size, max: latencies.max },
+      max_retained_samples_per_scan: results.map { |r| r.last.first }.max,
+      max_retained_sql_bytes_per_scan: results.map { |r| r.last.last }.max
+    }
+  end
+
+  def run
+    scans = Integer(ENV.fetch("SCANS", "100"))
+    queries = Integer(ENV.fetch("QUERIES", "30"))
+    concurrency = ENV.fetch("CONCURRENCY", "1,4,16").split(",").map { |value| Integer(value) }
+    abort "SCANS, QUERIES and CONCURRENCY must be positive" unless [scans, queries, *concurrency].all?(&:positive?)
+
+    # Warm parser/subscriber/configuration paths before measuring.
+    AndOne.capture_for_test { emit(queries, :active_n_plus_one) }
+    %i[disabled active_clean active_n_plus_one].each do |mode|
+      concurrency.each { |threads| puts JSON.generate(measure(mode, threads, scans, queries)) }
+    end
+  end
+end
+
+CaptureBenchmark.run

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,0 +1,102 @@
+# SQL capture boundaries and cost
+
+## Execution context
+
+A scan belongs to the **current Ruby fiber**, not every fiber in its thread.
+AndOne's internal `ExecutionContext` deliberately uses Ruby's fiber-local
+`Thread#[]` storage, independently of ActiveSupport's configurable isolation
+level. Interleaved fibers and concurrent threads do not share a detector or pause
+state. Nested scans in the same fiber reuse the outer scan; nested pause blocks
+restore the previous state. Exceptions, `return`, `break`, and `throw` release an
+owned scan without reporting incomplete results.
+
+Child fibers and child threads **do not inherit** a scan or its pause state. Wrap
+synchronous work in its own `AndOne.scan` inside the child if needed. Results are
+independent; they are not merged into the parent's results. Do not copy the
+internal detector between execution contexts. Automatic propagation is not
+supported. Request/job wrappers cover synchronous SQL while invoking the app/job,
+not subsequent lazy response-body enumeration or detached work.
+
+### ActiveRecord `load_async`
+
+Background SQL is **unsupported** for N+1 attribution. Events with `async: true`
+are deliberately excluded, even if delivered in an active scan. Rails can buffer
+worker SQL notifications and publish them when a caller consumes the result:
+that stack identifies result consumption, not the initiating query, and may be
+inside a completely different scan. Merely looking up the current detector would
+produce false attribution.
+
+`load_async` that falls back to ordinary synchronous execution (`async: false` or
+absent) is captured normally if its notification is emitted in the scan's fiber.
+Consequently async workload detection can depend on executor/fallback behavior;
+it is **not** a reliable test of async N+1s. Use explicit synchronous workloads
+when asserting query behavior. No mutable state is propagated to workers, and no
+per-query warnings are emitted. The real file-backed SQLite regression test
+verifies worker execution, deferred caller-thread notification, exclusion from
+an unrelated consumer scan, and synchronous fallback on the installed Rails
+version. It does not promise identical notification internals across all Rails
+versions/adapters.
+
+## Subscriber and retention
+
+Requiring AndOne installs one process-lifetime `sql.active_record` subscriber.
+Installation is mutex-protected and idempotent. Starting/finishing scans never
+adds/removes listeners, including on exceptions; cleanup releases only the
+fiber's detector. Inactive/paused contexts return before SQL parsing, connection
+metadata, or stack capture. Cached and schema events are excluded as before.
+
+Each (full call-stack location, configured connection, normalized SQL shape)
+group retains an exact occurrence counter, the **first five SQL samples**, and
+one representative stack/metadata record. `Detection#count` is the total, while
+`Detection#queries` is now a bounded sample, not a complete query history. Text,
+JSON, and aggregate storage continue to use the exact count. Stack locations
+must still be captured per eligible event to preserve existing full-stack
+location/ignore semantics, but later occurrences do not replace retained stacks
+or metadata. No bind objects or connection objects are retained.
+
+This bounds repeated-occurrence retention, **not total scan memory**: distinct
+shapes/stacks/connections still create groups, and individual SQL strings and
+stack depth are not byte-capped. SQL parsing and stack fingerprinting still cost
+work per eligible event. Global storage retention and SQL redaction are separate
+concerns; do not treat these samples as sanitized SQL.
+
+Configured `ignore_queries` regexes continue excluding individual events before
+counting. Ignore-file `query:` rules instead suppress a whole repeated group if
+**any** occurrence matches, including SQL arriving after the sample limit. They
+are evaluated during capture against the ignore-list instance selected at scan
+start. Reload ignore files between scans, not during a scan. Other ignore rules
+and thresholds continue to apply normally.
+
+## Reproducible benchmark
+
+```sh
+bundle exec ruby bench/capture.rb
+SCANS=200 QUERIES=100 CONCURRENCY=1,4,16 bundle exec ruby bench/capture.rb
+```
+
+The standalone harness emits JSONL for disabled, active-clean (distinct shapes
+with no repetition), and active-N+1 workloads at each concurrency. Output reports
+process-wide allocations, allocations per notification, throughput, mean/max scan
+latency, and maximum retained sample count/SQL bytes per scan (including clean
+groups). It warms capture paths and excludes reporting/persistence and database
+latency. Threads run concurrently but remain subject to the Ruby VM/GVL; this is
+a capture-overhead benchmark, not a database or Puma capacity estimate. Compare
+runs on the same Ruby/machine with the same parameters. There are no wall-clock
+CI thresholds, timer threads, or background queues in capture itself.
+
+Example local run (Ruby 4.0.6, Rails 8.1.2, Linux x86_64;
+`SCANS=20 QUERIES=30 CONCURRENCY=1,4,16`):
+
+| Workload | Threads | Notifications/s | Allocations/notification | Mean scan ms | Retained samples/scan |
+|---|---:|---:|---:|---:|---:|
+| disabled | 1 | 333737 | 9.8 | 0.09 | 0 |
+| disabled | 4 | 366592 | 9.8 | 0.08 | 0 |
+| disabled | 16 | 378950 | 9.8 | 0.08 | 0 |
+| active_clean | 1 | 12180 | 286.9 | 2.46 | 30 |
+| active_clean | 4 | 12484 | 286.9 | 2.40 | 30 |
+| active_clean | 16 | 12444 | 286.9 | 2.41 | 30 |
+| active_n_plus_one | 1 | 22388 | 177.9 | 1.33 | 5 |
+| active_n_plus_one | 4 | 20965 | 177.9 | 1.43 | 5 |
+| active_n_plus_one | 16 | 22616 | 177.9 | 1.33 | 5 |
+
+These are illustrative measurements, not a speedup claim or performance guarantee.

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -5,6 +5,8 @@ require "active_record"
 require "rails/railtie"
 
 require_relative "and_one/version"
+require_relative "and_one/execution_context"
+require_relative "and_one/sql_subscriber"
 require_relative "and_one/test_capture"
 require_relative "and_one/reporting"
 
@@ -36,7 +38,7 @@ module AndOne
       @enabled != false
     end
 
-    # Start scanning for N+1 queries on the current thread.
+    # Start scanning for N+1 queries in the current fiber.
     # Can be used with a block or as start/finish pair.
     def scan
       return block_given? ? yield : nil unless enabled?
@@ -59,29 +61,29 @@ module AndOne
     end
 
     def scanning?
-      !!thread_state[:and_one_detector]
+      !!execution_context[:and_one_detector]
     end
 
     def pause
       if block_given?
-        was_paused = thread_state[:and_one_paused]
-        thread_state[:and_one_paused] = true
+        was_paused = execution_context[:and_one_paused]
+        execution_context[:and_one_paused] = true
         begin
           yield
         ensure
-          thread_state[:and_one_paused] = was_paused
+          execution_context[:and_one_paused] = was_paused
         end
       else
-        thread_state[:and_one_paused] = true
+        execution_context[:and_one_paused] = true
       end
     end
 
     def resume
-      thread_state[:and_one_paused] = false
+      execution_context[:and_one_paused] = false
     end
 
     def paused?
-      !!thread_state[:and_one_paused]
+      !!execution_context[:and_one_paused]
     end
 
     def aggregate
@@ -117,12 +119,13 @@ module AndOne
     private
 
     def start_scan
-      thread_state[:and_one_detector] = Detector.new(
+      execution_context[:and_one_detector] = Detector.new(
         allow_stack_paths: allow_stack_paths || [],
         ignore_queries: ignore_queries || [],
-        min_n_queries: effective_min_n_queries
+        min_n_queries: effective_min_n_queries,
+        ignore_list: ignore_list
       )
-      thread_state[:and_one_paused] = false
+      execution_context[:and_one_paused] = false
     end
 
     # Resolve the effective min_n_queries, checking per-environment thresholds
@@ -162,23 +165,18 @@ module AndOne
     end
 
     def release_scan(owned_detector)
-      owned_detector.send(:unsubscribe)
-    rescue StandardError
-      # Cleanup must not replace an application exception or nonlocal exit.
-      nil
-    ensure
-      if detector.equal?(owned_detector)
-        thread_state[:and_one_detector] = nil
-        thread_state[:and_one_paused] = false
-      end
+      return unless detector.equal?(owned_detector)
+
+      execution_context[:and_one_detector] = nil
+      execution_context[:and_one_paused] = false
     end
 
     def detector
-      thread_state[:and_one_detector]
+      execution_context[:and_one_detector]
     end
 
-    def thread_state
-      Thread.current
+    def execution_context
+      ExecutionContext
     end
 
     def apply_ignore_filter(detections)
@@ -248,3 +246,5 @@ require_relative "and_one/middleware"
 require_relative "and_one/active_job_hook"
 require_relative "and_one/sidekiq_middleware"
 require_relative "and_one/railtie" if defined?(Rails::Railtie)
+
+AndOne::SqlSubscriber.install!

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -6,6 +6,7 @@ require "json"
 module AndOne
   # Represents a single N+1 detection: the repeated queries, their call site, and metadata.
   class Detection
+    # queries contains representative samples; count is the exact occurrence total.
     attr_reader :queries, :caller_locations, :count, :adapter, :connection_id
 
     def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil,

--- a/lib/and_one/detector.rb
+++ b/lib/and_one/detector.rb
@@ -4,130 +4,78 @@ require_relative "read_statement"
 require_relative "connection_context"
 
 module AndOne
-  # Subscribes to ActiveRecord SQL notifications and detects N+1 query patterns.
-  # Each instance tracks queries for a single request/block scope.
+  # Counts query shapes within one execution context. SQL samples, callers and
+  # connection metadata are retained once per group, not once per occurrence.
   class Detector
     DEFAULT_ALLOW_LIST = [
       %r{active_record/relation.*preload_associations},
       %r{active_record/validations/uniqueness}
     ].freeze
+    SAMPLE_LIMIT = 5
+    Group = Struct.new(:total, :queries, :callers, :metadata, :ignored)
 
     attr_reader :detections
 
-    def initialize(allow_stack_paths: [], ignore_queries: [], min_n_queries: 2)
-      @allow_stack_paths = allow_stack_paths
+    def initialize(allow_stack_paths: [], ignore_queries: [], min_n_queries: 2, ignore_list: nil)
+      @allow_stack_paths = DEFAULT_ALLOW_LIST + allow_stack_paths
       @ignore_queries = ignore_queries
       @min_n_queries = min_n_queries
-
-      # location_key => count
-      @query_counter = Hash.new(0)
-      # location_key => [sql, ...]
-      @query_holder = Hash.new { |h, k| h[k] = [] }
-      # location_key => caller_locations
-      @query_callers = {}
-      # location_key => additional metadata from AR notification
-      @query_metadata = {}
-
+      @ignore_list = ignore_list
+      @groups = {}
       @detections = []
-
-      subscribe
     end
 
     def finish
-      unsubscribe
       analyze
       @detections
     end
 
-    private
+    def record(payload)
+      sql = payload[:sql]
+      return if payload[:name] == "SCHEMA" || payload[:cached] || payload[:async]
+      return if @ignore_queries.any? { |pattern| pattern.match?(sql) }
 
-    def subscribe
-      # IMPORTANT: The notification callback fires on whatever thread triggered the SQL,
-      # NOT necessarily the thread that created this Detector. We must look up the
-      # current thread's detector (via Thread.current) to avoid cross-thread contamination.
-      # We store our object_id so the callback can verify it's writing to the correct instance.
-      detector_id = object_id
+      metadata = ConnectionContext.metadata(payload)
+      return unless ReadStatement.eligible?(sql, adapter: metadata[:connection_adapter])
 
-      @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        next unless AndOne.scanning? && !AndOne.paused?
-
-        # Only record if the current thread's detector is THIS detector.
-        # Under Puma, multiple Detectors may be subscribed simultaneously;
-        # each must only process its own thread's queries.
-        current_detector = Thread.current[:and_one_detector]
-        next unless current_detector&.object_id == detector_id
-
-        sql = payload[:sql]
-        name = payload[:name]
-
-        next if name == "SCHEMA"
-        next if payload[:cached]
-        next if current_detector.send(:ignored?, sql)
-
-        metadata = ConnectionContext.metadata(payload)
-        next unless ReadStatement.eligible?(sql, adapter: metadata[:connection_adapter])
-
-        current_detector.send(:record_query, sql, metadata)
-      end
+      record_query(sql, metadata)
     end
 
-    def unsubscribe
-      ActiveSupport::Notifications.unsubscribe(@subscriber) if @subscriber
-      @subscriber = nil
+    private
+
+    def analyze
+      @detections = @groups.values.filter_map do |group|
+        next if group.total < @min_n_queries || group.ignored
+
+        Detection.new(
+          queries: group.queries,
+          caller_locations: group.callers,
+          count: group.total,
+          adapter: group.metadata[:connection_adapter],
+          connection_id: group.metadata[:connection_id]
+        )
+      end
     end
 
     def record_query(sql, metadata)
       locations = caller_locations
-      location_key = [location_fingerprint(locations), metadata[:connection_id]]
+      key = [location_fingerprint(locations), metadata[:connection_id],
+             Fingerprint.generate(sql, adapter: metadata[:connection_adapter])]
+      group = @groups[key] ||= new_group(locations, metadata)
+      group.total += 1
+      # Query ignore rules historically inspect ALL occurrences. Evaluate before
+      # dropping samples so a late literal match still suppresses the whole group.
+      group.ignored ||= @ignore_list&.query_ignored?(sql)
+      group.queries << sql if group.queries.size < SAMPLE_LIMIT
+    end
 
-      @query_counter[location_key] += 1
-      @query_holder[location_key] << sql
-
-      # Only store caller on the second occurrence to save memory
-      return unless @query_counter[location_key] >= 2
-
-      @query_callers[location_key] = locations
-      @query_metadata[location_key] ||= metadata
+    def new_group(locations, metadata)
+      ignored = locations.any? { |frame| @allow_stack_paths.any? { |pattern| frame.to_s.match?(pattern) } }
+      Group.new(total: 0, queries: [], callers: locations, metadata: metadata, ignored: ignored)
     end
 
     def location_fingerprint(locations)
       locations.map { |loc| [loc.path, loc.lineno] }
-    end
-
-    def analyze
-      @query_counter.each do |location_key, count|
-        next if count < @min_n_queries
-
-        queries = @query_holder[location_key]
-        callers = @query_callers[location_key]
-        metadata = @query_metadata[location_key] || {}
-
-        next unless callers
-
-        # Group by fingerprint to confirm they're actually the same query shape
-        grouped = queries.group_by { |q| Fingerprint.generate(q, adapter: metadata[:connection_adapter]) }
-        repeated = grouped.values.select { |group| group.size >= @min_n_queries }
-
-        next if repeated.empty?
-
-        caller_strings = callers.map(&:to_s)
-        all_allow = DEFAULT_ALLOW_LIST + @allow_stack_paths
-        next if caller_strings.any? { |frame| all_allow.any? { |pattern| frame.match?(pattern) } }
-
-        repeated.each do |query_group|
-          @detections << Detection.new(
-            queries: query_group,
-            caller_locations: callers,
-            count: query_group.size,
-            adapter: metadata[:connection_adapter],
-            connection_id: metadata[:connection_id]
-          )
-        end
-      end
-    end
-
-    def ignored?(sql)
-      @ignore_queries.any? { |pattern| pattern.match?(sql) }
     end
   end
 end

--- a/lib/and_one/execution_context.rb
+++ b/lib/and_one/execution_context.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AndOne
+  # Ruby's Thread#[] is intentionally fiber-local. Never share mutable detectors
+  # with child fibers, threads, or ActiveRecord's async executor.
+  module ExecutionContext
+    def self.[](key)
+      Thread.current[key]
+    end
+
+    def self.[]=(key, value)
+      Thread.current[key] = value
+    end
+
+    def self.active_detector
+      self[:and_one_detector] unless self[:and_one_paused]
+    end
+  end
+end

--- a/lib/and_one/ignore_file.rb
+++ b/lib/and_one/ignore_file.rb
@@ -42,6 +42,11 @@ module AndOne
       @rules.any? { |rule| matches?(rule, detection, raw_caller_strings) }
     end
 
+    # Used during capture so query rules also see SQL beyond the sample limit.
+    def query_ignored?(sql)
+      @rules.any? { |rule| rule.type == :query && sql.include?(rule.pattern) }
+    end
+
     private
 
     def parse

--- a/lib/and_one/sql_subscriber.rb
+++ b/lib/and_one/sql_subscriber.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AndOne
+  # One process-lifetime subscription; scan cleanup only releases local state.
+  module SqlSubscriber
+    @mutex = Mutex.new
+
+    def self.install!
+      @mutex.synchronize do
+        return @subscriber if @subscriber
+
+        @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+          detector = ExecutionContext.active_detector
+          detector&.record(payload)
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/async_capture.rb
+++ b/test/fixtures/async_capture.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# A real file-backed SQLite pool is required: :memory: disables async support.
+require "and_one"
+require "timeout"
+
+ActiveRecord.async_query_executor = :global_thread_pool
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "async.sqlite3", pool: 5)
+ActiveRecord::Schema.define { create_table(:widgets) { |t| t.string :name } }
+class Widget < ActiveRecord::Base; end
+Widget.create!(name: "one")
+
+AndOne.raise_on_detect = true
+AndOne.notifications_callback = ->(*) { abort "unexpected reporting" }
+caller_thread = Thread.current
+notifications = []
+subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+  notifications << [Thread.current, payload[:async]] if payload[:name] == "Widget Load"
+end
+
+# Observe actual background completion without racing result consumption (which
+# is allowed to execute the query synchronously if the worker hasn't started).
+completed = Queue.new
+observer = Module.new do
+  define_method(:execute_or_skip) do
+    super()
+  ensure
+    completed << Thread.current
+  end
+end
+ActiveRecord::FutureResult.prepend(observer)
+tracker = ActiveRecord::Base.asynchronous_queries_tracker
+tracker.start_session
+begin
+  relations = nil
+  initial = AndOne.capture_for_test do
+    relations = 3.times.map { |i| Widget.where(id: i + 1).load_async }
+    workers = Timeout.timeout(10) { 3.times.map { completed.pop } }
+    abort "not executed by workers" unless workers.all? { |thread| thread != caller_thread }
+  end
+  abort "scheduled queries attributed to caller" unless initial.empty?
+  abort "notifications flushed too early" unless notifications.empty?
+
+  # Rails buffers worker events and publishes them when another scope consumes
+  # the result. They must not contaminate that unrelated scan.
+  consumed = AndOne.capture_for_test { relations.each(&:to_a) }
+  abort "async events contaminated consumer" unless consumed.empty?
+  abort "unexpected notification boundary: #{notifications.inspect}" unless notifications.size == 3 && notifications.all? do |thread, async|
+    thread == caller_thread && async
+  end
+  puts "async worker execution; caller notification; excluded from scan"
+ensure
+  tracker.finalize_session
+  ActiveSupport::Notifications.unsubscribe(subscriber)
+end
+
+# With the executor disabled, load_async falls back to ordinary synchronous SQL.
+ActiveRecord::Base.connection_pool.disconnect!
+ActiveRecord.async_query_executor = nil
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "async.sqlite3")
+detections = AndOne.capture_for_test { 3.times { |i| Widget.where(id: i + 1).load_async.to_a } }
+abort "synchronous fallback not captured" unless detections.map(&:count) == [3]
+puts "synchronous fallback captured"

--- a/test/test_bounded_capture.rb
+++ b/test/test_bounded_capture.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+
+class TestBoundedCapture < Minitest::Test
+  include AndOneTestHelper
+
+  def emit(count)
+    count.times do |i|
+      ActiveSupport::Notifications.instrument("sql.active_record", name: "Load", sql: "SELECT * FROM posts WHERE id = #{i}")
+    end
+  end
+
+  def test_large_scan_has_exact_count_and_bounded_samples
+    AndOne.min_n_queries = 1000 # Thresholds must use counts, not sample lengths.
+    detections = AndOne.capture_for_test { emit(10_000) }
+    assert_equal 1, detections.size
+    assert_equal 10_000, detections.first.count
+    assert_equal AndOne::Detector::SAMPLE_LIMIT, detections.first.queries.size
+    assert_equal 10_000, AndOne::JsonFormatter.new.format_hashes(detections).first[:query_count]
+    AndOne.aggregate.record(detections.first)
+    persisted = AndOne.aggregate.detections.values.first.detection
+    assert_equal 10_000, persisted.count
+    assert_equal detections.first.queries, persisted.queries
+  end
+
+  def test_mixed_shapes_at_same_stack_have_independent_counts
+    detections = AndOne.capture_for_test do
+      100.times do |i|
+        table = i.even? ? "posts" : "comments"
+        ActiveSupport::Notifications.instrument("sql.active_record", name: "Load", sql: "SELECT * FROM #{table} WHERE id = #{i}")
+      end
+    end
+    assert_equal %w[comments posts], detections.map(&:table_name).sort
+    assert_equal [50, 50], detections.map(&:count)
+  end
+
+  def test_query_ignore_sees_unsampled_literals_and_ignores_whole_group
+    path = File.join(@aggregate_tmpdir, "ignore")
+    File.write(path, "query:id = 99\n")
+    AndOne.ignore_file_path = path
+    AndOne.reload_ignore_file!
+    assert_empty(AndOne.capture_for_test { emit(100) })
+  end
+
+  def test_configured_query_ignore_still_excludes_only_matching_events
+    AndOne.ignore_queries = [/id = 99\z/]
+    detections = AndOne.capture_for_test { emit(100) }
+    assert_equal 99, detections.first.count
+  end
+
+  def test_callers_and_metadata_are_not_replaced_on_later_occurrences
+    AndOne.scan
+    detector = AndOne::ExecutionContext.active_detector
+    first = nil
+    3.times do
+      emit(1)
+      group = detector.instance_variable_get(:@groups).values.first
+      first ||= [group.callers, group.metadata]
+      assert_same first[0], group.callers
+      assert_same first[1], group.metadata
+    end
+  ensure
+    AndOne.finish
+  end
+
+  def test_one_subscriber_during_concurrent_scans_and_repeated_installation
+    listeners = ActiveSupport::Notifications.notifier.listeners_for("sql.active_record").dup
+    ready = Queue.new
+    release = Queue.new
+    threads = Array.new(12) do
+      Thread.new do
+        AndOne::SqlSubscriber.install!
+        AndOne.capture_for_test do
+          ready << true
+          release.pop
+          emit(20)
+        end
+      end
+    end
+    Timeout.timeout(10) { threads.size.times { ready.pop } }
+    assert_equal listeners, ActiveSupport::Notifications.notifier.listeners_for("sql.active_record")
+    threads.size.times { release << true }
+    threads.each { |thread| assert_equal [20], thread.value.map(&:count) }
+    assert_equal listeners, ActiveSupport::Notifications.notifier.listeners_for("sql.active_record")
+  ensure
+    threads&.each { |thread| thread.kill if thread.alive? }
+    threads&.each(&:join)
+  end
+end

--- a/test/test_execution_context.rb
+++ b/test/test_execution_context.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class TestExecutionContext < Minitest::Test
+  include AndOneTestHelper
+
+  def emit
+    3.times do
+      ActiveSupport::Notifications.instrument("sql.active_record", name: "Load", sql: "SELECT * FROM posts WHERE id = 1")
+    end
+  end
+
+  def test_interleaved_fibers_isolate_capture_and_pause
+    first = Fiber.new do
+      AndOne.capture_for_test do
+        AndOne.pause do
+          Fiber.yield
+          assert AndOne.paused?
+          emit
+        end
+        emit
+      end
+    end
+    second = Fiber.new do
+      AndOne.capture_for_test do
+        refute AndOne.paused?
+        2.times do |i|
+          emit
+          Fiber.yield if i.zero?
+        end
+      end
+    end
+    first.resume
+    second.resume
+    refute AndOne.scanning?
+    assert_equal [3], first.resume.map(&:count)
+    assert_equal [6], second.resume.map(&:count)
+    refute AndOne.scanning?
+  end
+
+  def test_child_fiber_does_not_inherit_scan_and_cleans_up_on_throw
+    detections = AndOne.capture_for_test do
+      Fiber.new do
+        refute AndOne.scanning?
+        emit
+        catch(:done) { AndOne.scan { AndOne.pause { throw :done } } }
+        refute AndOne.scanning?
+        refute AndOne.paused?
+      end.resume
+    end
+    assert_empty detections
+  end
+
+  def test_child_thread_does_not_inherit_but_can_start_its_own_scan
+    child = nil
+    detections = AndOne.capture_for_test do
+      child = Thread.new do
+        refute AndOne.scanning?
+        emit
+        AndOne.capture_for_test { emit }
+      end.value
+    end
+    assert_empty detections
+    assert_equal [3], child.map(&:count)
+  end
+
+  def test_async_events_delivered_in_an_active_scan_are_not_misattributed
+    detections = AndOne.capture_for_test do
+      3.times do
+        ActiveSupport::Notifications.instrument("sql.active_record", name: "Load", sql: "SELECT * FROM posts", async: true)
+      end
+    end
+    assert_empty detections
+  end
+
+  def test_real_load_async_notification_boundaries
+    fixture = File.expand_path("fixtures/async_capture.rb", __dir__)
+    Dir.mktmpdir("and_one_async") do |root|
+      output, status = Open3.capture2e(RbConfig.ruby, "-I", File.expand_path("../lib", __dir__), fixture, chdir: root)
+      assert status.success?, output
+      assert_includes output, "async worker execution; caller notification; excluded from scan"
+      assert_includes output, "synchronous fallback captured"
+    end
+  end
+end

--- a/test/test_scan_lifecycle.rb
+++ b/test/test_scan_lifecycle.rb
@@ -115,7 +115,6 @@ class TestScanLifecycle < Minitest::Test
     owned.define_singleton_method(:analyze) { raise "analysis failure" }
 
     assert_raises(RuntimeError) { AndOne.finish }
-    assert_nil owned.instance_variable_get(:@subscriber)
     assert_released
     assert_empty AndOne.finish
   end


### PR DESCRIPTION
## Summary
Fixes #14. Fixes #15.

These related issues share the notification dispatch path, so this PR handles them together without adding propagation or changing storage backends.

- Install one idempotent process-lifetime SQL subscriber with an inactive/paused fast path; scan cleanup releases only local state.
- Group during capture and retain five representative SQL samples per shape/location/connection, exact occurrence counts, and one stack/metadata record. Evaluate ignore-file query rules on every occurrence, including discarded samples.
- Introduce an explicit fiber-local execution context. Child fibers/threads do not inherit detectors; independent child scans remain supported.
- Exclude async-tagged events: real Rails worker queries can publish notifications later in a different consumer scan. Preserve synchronous load_async fallback capture.
- Document coverage/retention limitations and add a standalone allocation/latency/throughput/concurrency benchmark with sample measurements.

## Validation
- `bundle exec rake test`: 229 runs, 1087 assertions, zero failures/errors/skips.
- `bundle exec rubocop`: 69 files, no offenses.
- `SCANS=20 QUERIES=30 bundle exec ruby bench/capture.rb`: disabled, active-clean, and active-N+1 workloads at 1/4/16 threads.
- Real file-backed SQLite load_async subprocess on Ruby 4.0.6 / Rails 8.1.2 verifies worker execution, deferred caller notifications, unrelated-scan exclusion, and synchronous fallback.
- Regression coverage for concurrent listener count, interleaved fibers, child threads, pause/cleanup, 10,000-query exact counts and persistence, and ignore matches beyond retained samples.

## Explicit limits
Samples are bounded per group, not total scan memory or SQL byte size. Full stack locations are still captured to preserve attribution/ignore semantics. Background-query attribution and automatic context propagation remain unsupported; there is no universal async/fiber scheduler integration or compatibility-matrix claim.