### PR TITLE
Honor initializer configuration and make logfile delivery reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- Honor Rails application initializer paths, formats, and explicit disable settings before service I/O; rebuild cached services when their configuration changes between scans (#7).
+- Flush logfile findings before exit, retain a bounded retry buffer on failures, and keep callbacks outside output locks without suppressing N+1 enforcement (#17).
 - Recognize case-insensitive reads and read CTEs conservatively, preserve ordered stack frames, and attribute/isolate SQL using the emitting connection (#5).
 - Keep the same SQL shape visible at distinct application locations and connection contexts across aggregate, dashboard, and logfile output (#6).
 - Resolve unambiguous belongs-to/has-one/has-many association directions and custom keys without retaining stale model caches; abstain on ambiguous/complex associations (#11).

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Starting a matcher inside an already active scan raises `ArgumentError` **before
 
 - **Development**: Logs N+1 warnings to Rails logger and stderr
 - **Test**: Raises `AndOne::NPlus1Error` so N+1s fail your test suite
-- **Production**: Completely disabled (not even loaded)
+- **Production**: Disabled by default if loaded; the recommended Gemfile group excludes it
 
 ## Configuration
 
@@ -326,6 +326,20 @@ AndOne.configure do |config|
   }
 end
 ```
+
+### Configuration lifecycle
+
+Rails defaults are applied before `config/initializers`, without overwriting explicitly assigned settings (including `logfile = nil` or `false`). Service setup and middleware registration happen after those initializers. Development/test enable scanning and a logfile at `Rails.root/log/and_one.log`; only test raises by default. Production is disabled by default, but can be explicitly enabled.
+
+Configure before scanning. Between scans, changing `aggregate_path` or `ignore_file_path` rebuilds the corresponding cached service on next access. Changing `logfile` or `logfile_format` first flushes the old writer, then replaces it; a flush failure raises and rejects that configuration change. Do not reconfigure while requests/jobs are running. Other settings are read by subsequent scans/reports. Boot still resets the configured aggregate and truncates the configured logfile; shared-session lifecycle improvements are tracked separately in #8.
+
+### Logfile delivery and failures
+
+New, ignore-filtered findings are flushed synchronously after each reporting scan, so they are visible before process exit. First-occurrence deduplication still applies: later occurrences update the aggregate, not the logfile. Buffered failures are retried on the next scan containing findings (even already-known findings), or explicitly with `AndOne.logfile_writer&.flush!`. Rails also attempts a final flush at exit. No timer threads are created.
+
+Format/open/write failures retain pending entries. Cooperating processes use file locks; failed partial appends are rolled back when the filesystem permits. The retry buffer holds at most 1,000 unique findings; overflow rejects the new batch with a rate-limited diagnostic during reporting, preserving previously accepted entries. Newly rejected findings are not automatically redelivered because aggregate deduplication has already occurred. This is best-effort delivery, not crash durability or exactly-once delivery; shutdown, rollback failure, or buffer exhaustion can lose findings.
+
+Callbacks run outside output locks and may reenter scanning. Callback and output `StandardError`s are diagnosed on stderr at most once per minute and do not fail application work or suppress configured `NPlus1Error` enforcement. `NPlus1Error` itself is always propagated, including from a nested callback scan. Callbacks are not retried. Explicit writer `record`/`flush!` calls still raise on failure. Aggregate persistence failures are a separate policy (tracked in #9).
 
 ## Manual Scanning
 

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -9,10 +9,12 @@ require_relative "and_one/execution_context"
 require_relative "and_one/sql_subscriber"
 require_relative "and_one/test_capture"
 require_relative "and_one/reporting"
+require_relative "and_one/configuration"
 
 module AndOne
   class NPlus1Error < StandardError; end
 
+  extend Configuration
   extend Reporting
   extend TestCapture
 
@@ -26,9 +28,8 @@ module AndOne
     attr_accessor :enabled, :raise_on_detect, :backtrace_cleaner,
                   :allow_stack_paths, :ignore_queries, :ignore_callers,
                   :min_n_queries, :notifications_callback,
-                  :ignore_file_path, :json_logging, :env_thresholds,
-                  :dev_toast, :dev_toast_position, :aggregate_path,
-                  :logfile, :logfile_format
+                  :json_logging, :env_thresholds,
+                  :dev_toast, :dev_toast_position
 
     def configure
       yield self

--- a/lib/and_one/configuration.rb
+++ b/lib/and_one/configuration.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module AndOne
+  # Service settings can change between scans. Flush the old writer before
+  # replacing it; a failed flush rejects the change rather than losing entries.
+  module Configuration
+    attr_reader :aggregate_path, :logfile, :logfile_format, :ignore_file_path
+
+    def aggregate_path=(value)
+      @singleton_mutex.synchronize do
+        @aggregate = nil unless @aggregate_path == value
+        @aggregate_path = value
+      end
+    end
+
+    def ignore_file_path=(value)
+      @singleton_mutex.synchronize do
+        @ignore_list = nil unless @ignore_file_path == value
+        @ignore_file_path = value
+      end
+    end
+
+    %i[logfile logfile_format].each do |setting|
+      define_method("#{setting}=") do |value|
+        @singleton_mutex.synchronize do
+          unless instance_variable_get("@#{setting}") == value
+            @logfile_writer&.flush!
+            @logfile_writer = nil
+          end
+          instance_variable_set("@#{setting}", value)
+        end
+      end
+    end
+
+    def apply_rails_defaults
+      active = Rails.env.development? || Rails.env.test?
+      defaults = { enabled: active, raise_on_detect: Rails.env.test?,
+                   logfile: active ? Rails.root.join("log/and_one.log").to_s : nil,
+                   dev_toast: Rails.env.development? }
+      defaults.each do |key, value|
+        public_send("#{key}=", value) unless instance_variable_defined?("@#{key}")
+      end
+    end
+  end
+end

--- a/lib/and_one/logfile_writer.rb
+++ b/lib/and_one/logfile_writer.rb
@@ -4,12 +4,11 @@ require "json"
 require "fileutils"
 
 module AndOne
-  # Buffers N+1 detections in memory (deduplicated by issue identity) and writes
-  # them to a log file on process exit.  Handles parallel workers (forked test
-  # processes, Puma cluster, etc.) by using file-level locking so all workers
-  # safely append.  Truncation of stale data is handled at boot in the railtie,
-  # before workers fork.
+  # A bounded retry buffer. Reporting flushes after each scan; file locking
+  # keeps cooperating processes' appends intact.
   class LogfileWriter
+    MAX_PENDING = 1000
+
     # Clear stale findings from a previous boot.  Called once in the railtie
     # before workers fork so every worker starts with a clean file.
     def self.truncate!(path)
@@ -26,34 +25,51 @@ module AndOne
     # Accept an array of Detection objects; deduplicate by issue identity.
     def record(detections)
       @mutex.synchronize do
-        detections.each do |d|
-          @entries[d.issue_id] ||= d
+        additions = detections.to_h { |d| [d.issue_id, d] }
+        if (@entries.keys | additions.keys).size > MAX_PENDING
+          raise IOError, "AndOne logfile retry buffer full (#{MAX_PENDING} findings); flush before retrying"
         end
+
+        @entries.merge!(additions) { |_key, existing, _new| existing }
       end
     end
 
     # Format all buffered entries and write to the log file with locking.
     def flush!
-      entries = @mutex.synchronize do
-        snapshot = @entries.values
-        @entries = {}
-        snapshot
-      end
-      return if entries.empty?
+      @mutex.synchronize do
+        return if @entries.empty?
 
-      output = format_entries(entries)
-      FileUtils.mkdir_p(File.dirname(@path))
-
-      File.open(@path, File::RDWR | File::CREAT, 0o644) do |f|
-        f.flock(File::LOCK_EX)
-        f.seek(0, IO::SEEK_END)
-        f.write("\n") if f.size.positive?
-        f.write(output)
-        f.flock(File::LOCK_UN)
+        output = "#{format_entries(@entries.values)}\n"
+        FileUtils.mkdir_p(File.dirname(@path))
+        append(output)
+        @entries.clear
       end
     end
 
     private
+
+    def append(output)
+      File.open(@path, File::RDWR | File::CREAT, 0o644) do |file|
+        file.flock(File::LOCK_EX)
+        original_size = file.size
+        begin
+          if original_size.positive?
+            file.seek(-1, IO::SEEK_END)
+            output = "\n#{output}" unless file.read(1) == "\n"
+          end
+          file.seek(0, IO::SEEK_END)
+          written = file.write(output)
+          raise IOError, "Incomplete AndOne logfile write" unless written == output.bytesize
+
+          file.flush
+        rescue StandardError
+          file.truncate(original_size)
+          raise
+        ensure
+          file.flock(File::LOCK_UN)
+        end
+      end
+    end
 
     def format_entries(entries)
       case @format

--- a/lib/and_one/railtie.rb
+++ b/lib/and_one/railtie.rb
@@ -2,14 +2,12 @@
 
 module AndOne
   class Railtie < Rails::Railtie
-    initializer "and_one.configure" do |app|
-      # Only activate in development and test by default
-      if Rails.env.development? || Rails.env.test?
-        AndOne.enabled = true
+    initializer "and_one.defaults", before: :load_config_initializers do
+      AndOne.apply_rails_defaults
+    end
 
-        # Default logfile for collecting all findings
-        AndOne.logfile = "log/and_one.log" if AndOne.logfile.nil?
-
+    initializer "and_one.configure", after: :load_config_initializers do |app|
+      if AndOne.enabled?
         # Truncate stale findings from previous boot before workers fork
         LogfileWriter.truncate!(AndOne.logfile)
 
@@ -22,18 +20,12 @@ module AndOne
         # Reset aggregate on server boot for a fresh session
         AndOne.aggregate.reset!
 
-        # In test, raise by default so N+1s fail the test suite
-        AndOne.raise_on_detect = true if Rails.env.test?
-
         # Rack middleware for web requests
         app.middleware.insert_before(0, AndOne::Middleware)
 
         if Rails.env.development?
           # Dev UI dashboard for N+1 overview
           app.middleware.use(AndOne::DevUI)
-
-          # Dev toast: show in-page N+1 notifications (default on in development)
-          AndOne.dev_toast = true if AndOne.dev_toast.nil?
         end
 
         # ActiveJob hook — covers all job backends (Sidekiq, GoodJob, SolidQueue, etc.)
@@ -49,8 +41,6 @@ module AndOne
             end
           end
         end
-      else
-        AndOne.enabled = false
       end
     end
 

--- a/lib/and_one/reporting.rb
+++ b/lib/and_one/reporting.rb
@@ -7,7 +7,12 @@ module AndOne
 
     def report(detections)
       new_detections = detections.select { |detection| aggregate.record(detection) }
-      report_new(new_detections) unless new_detections.empty?
+      safely_deliver do
+        writer = logfile_writer
+        writer&.record(new_detections)
+        writer&.flush!
+      end
+      safely_deliver { report_new(new_detections) } unless new_detections.empty?
       return unless raise_on_detect
 
       formatter = Formatter.new(backtrace_cleaner: backtrace_cleaner || default_backtrace_cleaner)
@@ -15,11 +20,12 @@ module AndOne
     end
 
     def report_new(detections)
-      logfile_writer&.record(detections)
       cleaner = backtrace_cleaner || default_backtrace_cleaner
       message = Formatter.new(backtrace_cleaner: cleaner).format(detections)
 
-      # Keep the existing first-occurrence callback and output contracts.
+      # User code must never run under the non-reentrant output mutex.
+      safely_deliver { notifications_callback&.call(detections, message) }
+
       @report_mutex.synchronize do
         if json_logging
           json_output = JsonFormatter.new(backtrace_cleaner: cleaner).format(detections)
@@ -30,12 +36,27 @@ module AndOne
           end
         end
 
-        notifications_callback&.call(detections, message)
         report_annotations(detections) if ENV["GITHUB_ACTIONS"]
         return if raise_on_detect || json_logging
 
         Rails.logger.warn("\n#{message}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
         warn("\n#{message}") if $stderr.tty?
+      end
+    end
+
+    # Sink failures are best-effort and must not suppress N+1 enforcement.
+    # Emit at most one diagnostic per minute, without invoking application code.
+    def safely_deliver
+      yield
+    rescue NPlus1Error
+      raise
+    rescue StandardError => e
+      @report_mutex.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if !@last_delivery_warning || now - @last_delivery_warning >= 60
+          @last_delivery_warning = now
+          warn "AndOne reporting failed (#{e.class}); logfile entries retained within retry-buffer limits"
+        end
       end
     end
 

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestConfiguration < Minitest::Test
+  include AndOneTestHelper
+
+  def test_aggregate_path_change_rebuilds_service
+    previous = AndOne.aggregate
+    AndOne.aggregate_path = File.join(@aggregate_tmpdir, "other")
+    refute_same previous, AndOne.aggregate
+    assert File.directory?(AndOne.aggregate_path)
+  end
+
+  def test_ignore_path_change_rebuilds_service
+    previous = AndOne.ignore_list
+    AndOne.ignore_file_path = File.join(@aggregate_tmpdir, "ignore")
+    refute_same previous, AndOne.ignore_list
+  end
+
+  def test_logfile_changes_flush_previous_writer_and_rebuild
+    path = File.join(@aggregate_tmpdir, "original.jsonl")
+    AndOne.logfile = path
+    AndOne.logfile_format = :json
+    original = AndOne.logfile_writer
+    original.record([AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)])
+    AndOne.logfile_format = :text
+    refute_same original, AndOne.logfile_writer
+    assert_equal "n_plus_one_detected", JSON.parse(File.read(path))["event"]
+    previous = AndOne.logfile_writer
+    AndOne.logfile = File.join(@aggregate_tmpdir, "other.log")
+    refute_same previous, AndOne.logfile_writer
+    AndOne.logfile = nil
+    assert_nil AndOne.logfile_writer
+  end
+
+  def test_failed_flush_rejects_configuration_change
+    path = File.join(@aggregate_tmpdir, "original.log")
+    AndOne.logfile = path
+    original = AndOne.logfile_writer
+    original.stub(:flush!, -> { raise IOError, "unavailable" }) do
+      assert_raises(IOError) { AndOne.logfile = nil }
+    end
+    assert_equal path, AndOne.logfile
+    assert_same original, AndOne.logfile_writer
+  end
+end

--- a/test/test_logfile_delivery.rb
+++ b/test/test_logfile_delivery.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+
+class TestLogfileDelivery < Minitest::Test
+  include AndOneTestHelper
+
+  def setup
+    super
+    @path = File.join(@aggregate_tmpdir, "findings.jsonl")
+    @detection = AndOne::Detection.new(queries: ["SELECT * FROM posts WHERE id = 1"], count: 3)
+    @writer = AndOne::LogfileWriter.new(path: @path, format: :json)
+  end
+
+  def test_format_failure_preserves_entries
+    @writer.record([@detection])
+    @writer.stub(:format_entries, ->(*) { raise ArgumentError, "bad format" }) do
+      assert_raises(ArgumentError) { @writer.flush! }
+    end
+    @writer.flush!
+    assert_equal [@detection.issue_id], logged_ids
+  end
+
+  def test_open_failure_preserves_entries
+    @writer.record([@detection])
+    File.stub(:open, ->(*) { raise Errno::EACCES }) do
+      assert_raises(Errno::EACCES) { @writer.flush! }
+    end
+    @writer.flush!
+    assert_equal [@detection.issue_id], logged_ids
+  end
+
+  def test_legacy_file_without_trailing_newline
+    File.write(@path, '{"existing":true}')
+    @writer.record([@detection])
+    @writer.flush!
+    assert_equal [nil, @detection.issue_id], logged_ids
+  end
+
+  def test_partial_write_is_rolled_back_and_retried
+    File.write(@path, "{\"existing\":true}\n")
+    @writer.record([@detection])
+    File.open(@path, File::RDWR) do |file|
+      original_write = file.method(:write)
+      file.stub(:write, lambda { |output|
+        original_write.call(output[0, 10])
+        raise IOError, "disk full"
+      }) do
+        File.stub(:open, ->(*, &block) { block.call(file) }) do
+          assert_raises(IOError) { @writer.flush! }
+        end
+      end
+    end
+    assert_equal "{\"existing\":true}\n", File.read(@path)
+    @writer.flush!
+    assert_equal [nil, @detection.issue_id], logged_ids
+  end
+
+  def test_concurrent_appends_survive_a_failed_flush
+    @writer.record([@detection])
+    entered = Queue.new
+    release = Queue.new
+    failure = Thread.new do
+      @writer.stub(:format_entries, lambda { |*|
+        entered << true
+        release.pop
+        raise IOError, "format failed"
+      }) do
+        assert_raises(IOError) { @writer.flush! }
+      end
+    end
+    entered.pop
+    other = AndOne::Detection.new(queries: ["SELECT * FROM comments"], count: 2)
+    recorder = Thread.new { @writer.record([other]) }
+    release << true
+    [failure, recorder].each(&:value)
+    @writer.flush!
+    assert_equal [@detection.issue_id, other.issue_id].sort, logged_ids.sort
+  end
+
+  def test_actual_processes_append_complete_records
+    %i[json text].each do |format|
+      FileUtils.rm_f(@path)
+      pids = 4.times.map do
+        fork do
+          writer = AndOne::LogfileWriter.new(path: @path, format: format)
+          10.times do
+            writer.record([@detection])
+            writer.flush!
+          end
+          exit! 0
+        end
+      end
+      pids.each { |pid| assert Process.wait2(pid).last.success? }
+      content = File.read(@path)
+      assert content.end_with?("\n")
+      if format == :json
+        assert_equal [@detection.issue_id] * 40, logged_ids
+      else
+        block = "#{@writer.send(:format_text, [@detection])}\n"
+        assert_equal block * 40, content
+      end
+    end
+  end
+
+  def test_retry_queue_is_bounded_without_losing_accepted_entries
+    @writer.record([@detection])
+    others = AndOne::LogfileWriter::MAX_PENDING.times.map do |i|
+      AndOne::Detection.new(queries: ["SELECT * FROM comments"], count: 2, issue_id: "issue-#{i}")
+    end
+    assert_raises(IOError) { @writer.record(others) }
+    @writer.flush!
+    assert_equal [@detection.issue_id], logged_ids
+  end
+
+  def test_reporting_retries_even_when_occurrence_is_deduplicated
+    AndOne.logfile = @path
+    AndOne.logfile_format = :json
+    AndOne.raise_on_detect = true
+    writer = AndOne.logfile_writer
+    capture_io do
+      writer.stub(:append, ->(*) { raise IOError, "unavailable" }) do
+        assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [@detection]) }
+      end
+    end
+    refute File.exist?(@path)
+    assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [@detection]) }
+    assert_equal [@detection.issue_id], logged_ids
+    assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [@detection]) }
+    assert_equal [@detection.issue_id], logged_ids
+  end
+
+  def test_callback_can_reenter_reporting_without_deadlock
+    other = AndOne::Detection.new(queries: ["SELECT * FROM comments"], count: 2)
+    calls = 0
+    AndOne.notifications_callback = lambda do |*|
+      calls += 1
+      AndOne.send(:report, [other]) if calls == 1
+    end
+    Timeout.timeout(3) { AndOne.send(:report, [@detection]) }
+    assert_equal 2, calls
+  end
+
+  def test_callback_errors_do_not_fail_application_or_suppress_enforcement
+    AndOne.notifications_callback = ->(*) { raise "callback failed" }
+    capture_io { AndOne.send(:report, [@detection]) }
+    AndOne.raise_on_detect = true
+    AndOne.aggregate.reset!
+    capture_io do
+      assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [@detection]) }
+    end
+  end
+
+  def test_nested_n_plus_one_errors_are_not_swallowed
+    AndOne.notifications_callback = ->(*) { raise AndOne::NPlus1Error, "nested scan" }
+    assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [@detection]) }
+  end
+
+  private
+
+  def logged_ids
+    File.readlines(@path).map { |line| JSON.parse(line)["issue_id"] }
+  end
+end

--- a/test/test_rails_configuration.rb
+++ b/test/test_rails_configuration.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class TestRailsConfiguration < Minitest::Test
+  LIB_PATH = File.expand_path("../lib", __dir__)
+
+  def boot(environment, initializer: "", before: "", assertions: "")
+    Dir.mktmpdir("and_one_boot") do |root|
+      FileUtils.mkdir_p(File.join(root, "config/initializers"))
+      File.write(File.join(root, "config/initializers/and_one.rb"), initializer)
+      source = <<~RUBY
+        require "rails/all"
+        require "and_one"
+        #{before}
+        class ConfigurationApp < Rails::Application
+          config.root = Dir.pwd
+          config.eager_load = false
+          config.secret_key_base = "test" * 32
+          config.logger = Logger.new(File::NULL)
+          config.active_support.deprecation = :stderr
+        end
+        Rails.application.initialize!
+        #{assertions}
+      RUBY
+      output, status = Open3.capture2e(
+        { "RAILS_ENV" => environment, "GITHUB_ACTIONS" => nil },
+        RbConfig.ruby, "-I", LIB_PATH, "-e", source, chdir: root
+      )
+      assert status.success?, output
+    end
+  end
+
+  def test_environment_defaults
+    %w[development test production].each do |environment|
+      active = environment != "production"
+      boot(environment, assertions: <<~RUBY)
+        abort "enabled" unless AndOne.enabled? == #{active}
+        abort "raise" unless AndOne.raise_on_detect == #{environment == "test"}
+        abort "toast" unless AndOne.dev_toast == #{environment == "development"}
+        abort "logfile" unless !!AndOne.logfile == #{active}
+        abort "middleware" unless Rails.application.middleware.any? { |m| m.klass == AndOne::Middleware } == #{active}
+        abort "unexpected storage" if !#{active} && File.exist?("tmp/and_one")
+      RUBY
+    end
+  end
+
+  def test_initializer_paths_and_format_are_used_before_io
+    boot("test", initializer: <<~RUBY, assertions: <<~RUBY)
+      abort "premature storage" if File.exist?("tmp/and_one")
+      AndOne.aggregate_path = Rails.root.join("custom_aggregate").to_s
+      AndOne.logfile = Rails.root.join("custom_logs/findings.jsonl").to_s
+      AndOne.logfile_format = :json
+      AndOne.raise_on_detect = false
+    RUBY
+      abort "default storage touched" if File.exist?("tmp/and_one")
+      abort "custom storage unused" unless File.directory?("custom_aggregate")
+      abort "raise overwritten" if AndOne.raise_on_detect
+      detection = AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)
+      AndOne.send(:report, [detection])
+      entry = JSON.parse(File.read("custom_logs/findings.jsonl"))
+      abort "wrong format" unless entry["event"] == "n_plus_one_detected"
+      abort "default logfile touched" if File.exist?("log/and_one.log")
+    RUBY
+  end
+
+  def test_explicit_disable_before_boot_and_in_initializer
+    ["AndOne.logfile = nil", "AndOne.logfile = false"].each do |setting|
+      boot("development", before: setting, assertions: 'abort "logfile enabled" if AndOne.logfile_writer')
+      boot("test", initializer: setting, assertions: 'abort "logfile enabled" if AndOne.logfile_writer')
+    end
+    boot("test", initializer: "AndOne.enabled = false", assertions: <<~RUBY)
+      abort "enabled" if AndOne.enabled?
+      abort "storage touched" if File.exist?("tmp/and_one")
+      abort "middleware installed" if Rails.application.middleware.any? { |m| m.klass == AndOne::Middleware }
+    RUBY
+    boot("test", before: "AndOne.enabled = false; AndOne.raise_on_detect = false", assertions: <<~RUBY)
+      abort "overwritten" if AndOne.enabled? || AndOne.raise_on_detect
+    RUBY
+  end
+
+  def test_explicit_production_enable
+    boot("production", initializer: "AndOne.enabled = true; AndOne.raise_on_detect = true", assertions: <<~RUBY)
+      abort "disabled" unless AndOne.enabled? && AndOne.raise_on_detect
+      abort "missing middleware" unless Rails.application.middleware.any? { |m| m.klass == AndOne::Middleware }
+    RUBY
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #7.
Fixes #17.

- Apply Rails defaults before application initializers and construct services afterward; honor custom paths/formats and explicit disables. Rebuild cached services on between-scan configuration changes, flushing the old writer before replacement.
- Flush new findings synchronously during reporting; retain failed batches for retry, cap pending findings at 1,000, and serialize complete appends across processes with rollback on write errors.
- Run callbacks outside output locks; diagnose sink/callback failures without suppressing configured N+1 enforcement.
- Document defaults, runtime reconfiguration, deduplication/retry behavior, and delivery limitations.

## Validation
- `bundle exec rake`: 248 tests, 1,141 assertions, no failures/errors/skips; RuboCop clean (73 files).
- Real minimal Rails subprocess boots cover development/test/production, custom initializer paths and JSON output, explicit nil/false logfile disable, and enable/raise overrides.
- Regression tests cover format/open/partial-write failures, concurrent recording during failed flushes, actual forked-process JSONL/text appends, bounded retries, reentrant callbacks, and enforcement independence.
- `git diff --check` clean.

## Scope and limitations
Boot resets/truncation remain unchanged pending #8; aggregate-store failure handling remains #9. Delivery is best-effort, not crash-durable or exactly-once. Retry-buffer overflow rejects new batches visibly while preserving accepted entries; rejected findings are not automatically redelivered after aggregate deduplication.