### PR TITLE
Test supported stacks and verify recommendation accuracy end-to-end

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,26 +4,100 @@ on:
   push:
     branches:
       - main
-
   pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }} / SQLite
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - '4.0.1'
-
+        include:
+          - ruby: '3.2'
+            rails: '7.0.0'
+          - ruby: '3.3'
+            rails: '7.2.0'
+          - ruby: '4.0'
+            rails: '8.1.0'
+    env:
+      BUNDLE_GEMFILE: gemfiles/compatibility.gemfile
+      RAILS_VERSION: ${{ matrix.rails }}
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run the default task
-        run: bundle exec rake
+          cache-version: ${{ matrix.rails }}
+      - run: bundle exec rake
+      - run: git diff --exit-code -- Gemfile.lock
+
+  adapters:
+    runs-on: ubuntu-latest
+    name: Rails ${{ matrix.rails }} / ${{ matrix.db }} integration
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: '3.2'
+            rails: '7.0.0'
+            db: postgresql
+          - ruby: '3.2'
+            rails: '7.0.0'
+            db: mysql2
+          - ruby: '4.0'
+            rails: '8.1.0'
+            db: postgresql
+          - ruby: '4.0'
+            rails: '8.1.0'
+            db: mysql2
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: and_one
+          POSTGRES_PASSWORD: and_one
+          POSTGRES_DB: and_one_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U and_one -d and_one_test"
+          --health-interval 10s --health-timeout 5s --health-retries 5
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: and_one
+          MYSQL_PASSWORD: and_one
+          MYSQL_DATABASE: and_one_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval 10s --health-timeout 5s --health-retries 10
+    env:
+      BUNDLE_GEMFILE: gemfiles/compatibility.gemfile
+      RAILS_VERSION: ${{ matrix.rails }}
+      DB: ${{ matrix.db }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: sudo apt-get update && sudo apt-get install -y libpq-dev default-libmysqlclient-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          cache-version: ${{ matrix.rails }}-${{ matrix.db }}
+      - name: Run portable corpus and prepared-query checks
+        run: |
+          if [ "$DB" = postgresql ]; then
+            export DATABASE_URL='postgresql://and_one:and_one@127.0.0.1:5432/and_one_test?prepared_statements=true'
+          else
+            export DATABASE_URL='mysql2://and_one:and_one@127.0.0.1:3306/and_one_test?prepared_statements=true'
+          fi
+          bundle exec ruby -Itest test/test_accuracy_corpus.rb
+      - run: git diff --exit-code -- Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 *.gem
+/gemfiles/*.lock

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ That's it. AndOne automatically activates in development and test environments v
 
 AndOne requires Ruby 3.2+ and ActiveRecord/ActiveSupport/Railties 7.0+ (choose versions compatible with your Ruby). Rails applications get automatic request/job integration. Outside a Rails application, “plain Ruby” support means **ActiveRecord SQL instrumentation**, not arbitrary database clients or other ORMs such as Sequel. Railties remains a runtime dependency; RSpec is optional and only needed for `and_one/rspec`. No public RBS signatures are currently shipped.
 
+CI exercises Ruby/Rails 3.2/7.0, 3.3/7.2, and 4.0/8.1 on SQLite, plus the oldest/current boundaries on PostgreSQL 16 and MySQL 8.0. A 17-scenario labeled corpus checks recommendation accuracy, known limitations, and before/after result equivalence and physical query counts. See [the support matrix and local reproduction commands](docs/compatibility.md).
+
 A standalone script can use:
 
 ```ruby

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,86 @@
+# Compatibility and accuracy checks
+
+## CI coverage
+
+The compatibility Gemfile selects an explicit Rails minor series (latest compatible
+patch/dependencies at resolution time). Its generated lockfile is separate from
+`Gemfile.lock`; neither CI nor the commands below updates the default lockfile.
+This is a bounded representative matrix, not a promise that every Ruby/Rails/adapter
+combination works:
+
+| Ruby | Rails | Checks |
+| --- | --- | --- |
+| 3.2 | 7.0 | Full suite + RuboCop on SQLite; corpus on PostgreSQL 16 and MySQL 8.0 |
+| 3.3 | 7.2 | Full suite + RuboCop on SQLite |
+| 4.0 | 8.1 | Full suite + RuboCop on SQLite; corpus on PostgreSQL 16 and MySQL 8.0 |
+
+Rails 7.0 uses sqlite3 1.x; Rails 7 uses JSON <3 because its encoder passes the
+removed `quirks_mode` option. These constraints are for the test stack, not extra
+runtime dependencies of AndOne. Use upstream-compatible dependency versions in
+applications too. The earlier ModuleLength offense has already been resolved by
+existing configuration/reporting extractions; the matrix runs lint without disabling it.
+
+The fast default remains `bundle exec rake`. To reproduce a matrix job, select its
+Ruby first (for example `mise use ruby@3.2`, or your preferred version manager):
+
+```sh
+export BUNDLE_GEMFILE=gemfiles/compatibility.gemfile
+export RAILS_VERSION=7.0.0 # or 7.2.0 / 8.1.0 with the corresponding Ruby
+bundle install
+bundle exec rake
+```
+
+Service-backed runs require libpq/MySQL client development libraries and a
+**disposable** database. The helper drops/recreates tables; never point this at an
+application database. For example, start PostgreSQL 16 or MySQL 8.0 using the service
+configuration in `.github/workflows/main.yml`, then:
+
+```sh
+export BUNDLE_GEMFILE=gemfiles/compatibility.gemfile RAILS_VERSION=8.1.0
+export DB=postgresql # or mysql2
+export DATABASE_URL='postgresql://and_one:and_one@127.0.0.1:5432/and_one_test?prepared_statements=true'
+# MySQL: mysql2://and_one:and_one@127.0.0.1:3306/and_one_test?prepared_statements=true
+bundle install
+bundle exec ruby -Itest test/test_accuracy_corpus.rb
+```
+
+Run only the portable corpus against service databases: some existing unit/stress
+tests deliberately replace the connection with SQLite. Unset `DATABASE_URL`, `DB`,
+`BUNDLE_GEMFILE`, and `RAILS_VERSION` when returning to default development. Generated
+`gemfiles/*.lock` files are ignored; remove them to reproduce fresh CI resolution,
+or retain them to repeat an exact local dependency set.
+
+## Labeled accuracy corpus
+
+`test/fixtures/accuracy_corpus.rb` defines 17 small scenarios and a reusable schema.
+Each label distinguishes workload truth from the detector's **current observed
+behavior**. Failures name the scenario, expected actionability, and limitations;
+there is deliberately no aggregate accuracy/marketing score.
+
+- Basic has-many/belongs-to, custom keys in both directions, has-one, and scoped
+  loading: candidate association advice. Both suggested `includes` and `preload`
+  are executed; ordered result IDs must be identical, physical queries must drop
+  to two, and repeated-query findings must disappear. Scoped fixtures include both
+  matching and non-matching rows.
+- Two same-table associations, polymorphic loading, and through loading: repeated
+  queries detected, but exact association advice is explicitly unsupported.
+- COUNT, EXISTS, and scalar reads: operation-specific guidance, not record-preload
+  advice.
+- Identical lookups and intentional batching: known false positives for the
+  association-N+1 interpretation. Tests record today's behavior, not endorse it.
+- Query-cache hits and preloaded loading: intentional non-N+1 examples without
+  findings. Cached queries do not count as physical database work.
+- One child load below the repetition threshold: an explicit known false negative
+  of threshold-based detection, rather than a claim that the workload scales.
+
+A separate integration check asserts prepared statements are enabled, observes real
+adapter bind metadata on repeated association queries, and checks preload removes
+the finding. Schema creation, fixture writes, and model metadata warmup are outside
+both scan and measurement. Each measurement begins uncached; only the cache scenario
+explicitly enables caching within that scope. Counts exclude cache hits, schema
+notifications, and transaction control. No timing assertions or arbitrary workload
+reruns are hidden in public APIs: before/after executions are explicit test cases.
+
+These are recommendation/actionability labels, not new public classification
+fields. Bind-based classification remains a separate issue (#21). The corpus is
+not exhaustive SQL coverage and does not establish causal association attribution.

--- a/gemfiles/compatibility.gemfile
+++ b/gemfiles/compatibility.gemfile
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+# Keep dependency resolution separate from the default development lockfile.
+gem "irb"
+# Rails 7's JSON encoder passes quirks_mode, removed in JSON 3.
+gem "json", "< 3" if ENV.fetch("RAILS_VERSION", "8.1.0").start_with?("7.")
+gem "minitest", "~> 5.16"
+gem "mysql2", "~> 0.5" if ENV["DB"] == "mysql2"
+gem "pg", "~> 1.5" if ENV["DB"] == "postgresql"
+gem "rails", "~> #{ENV.fetch("RAILS_VERSION", "8.1.0")}"
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.13"
+gem "rubocop", "~> 1.21"
+gem "sqlite3", ENV.fetch("RAILS_VERSION", "8.1.0").start_with?("7.0") ? "~> 1.4" : ">= 1.4"

--- a/test/fixtures/accuracy_corpus.rb
+++ b/test/fixtures/accuracy_corpus.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Small isolated schema: no generated Rails application and no adapter-specific SQL.
+module AccuracyCorpus
+  module_function
+
+  def setup!
+    connection = ActiveRecord::Base.connection
+    connection.create_table(:corpus_owners, force: true) { |t| t.string :code }
+    connection.create_table(:corpus_items, force: true) { |t| t.string :owner_code }
+    connection.create_table(:corpus_badges, force: true) { |t| t.integer :corpus_owner_id }
+    connection.create_table(:corpus_entries, force: true) do |t|
+      t.integer :corpus_owner_id
+      t.boolean :published
+    end
+    connection.create_table(:corpus_links, force: true) { |t| t.integer :corpus_owner_id }
+    connection.create_table(:corpus_notes, force: true) do |t|
+      t.integer :notable_id
+      t.string :notable_type
+    end
+    %w[Owner Item Badge Entry Link Note].each do |name|
+      Object.const_set("Corpus#{name}", Class.new(ActiveRecord::Base))
+    end
+    CorpusOwner.has_many :items, class_name: "CorpusItem", foreign_key: :owner_code, primary_key: :code
+    CorpusItem.belongs_to :owner, class_name: "CorpusOwner", foreign_key: :owner_code, primary_key: :code
+    CorpusOwner.has_one :badge, class_name: "CorpusBadge"
+    CorpusOwner.has_many :published_entries, -> { where(published: true) }, class_name: "CorpusEntry"
+    CorpusOwner.has_many :links, class_name: "CorpusLink"
+    CorpusOwner.has_many :other_links, class_name: "CorpusLink"
+    CorpusOwner.has_many :notes, as: :notable, class_name: "CorpusNote"
+    CorpusNote.belongs_to :notable, polymorphic: true
+    CorpusItem.has_many :notes, through: :owner
+    3.times do |index|
+      owner = CorpusOwner.create!(code: "owner-#{index}")
+      2.times { owner.items.create! }
+      owner.create_badge!
+      owner.published_entries.create!
+      CorpusEntry.create!(corpus_owner_id: owner.id, published: false)
+      owner.links.create!
+      owner.notes.create!
+    end
+    # Warm schema/type metadata outside both SQL capture and count measurement.
+    [CorpusOwner, CorpusItem, CorpusBadge, CorpusEntry, CorpusLink, CorpusNote].each(&:columns)
+  end
+
+  def teardown!
+    %w[Owner Item Badge Entry Link Note].each { |name| Object.send(:remove_const, "Corpus#{name}") }
+  end
+
+  # truth describes the workload; observed describes today's repeated-shape
+  # detector, NOT a claim that duplicate reads/batching are association N+1s.
+  def scenarios
+    [
+      { name: :has_many, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { Post }, association: :comments },
+      { name: :belongs_to, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { Post }, association: :author },
+      { name: :has_many_custom_key, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { CorpusOwner }, association: :items },
+      { name: :belongs_to_custom_key, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { CorpusItem }, association: :owner },
+      { name: :has_one, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { CorpusOwner }, association: :badge },
+      { name: :scoped_association, truth: :association_n_plus_one, observed: :candidate,
+        model: -> { CorpusOwner }, association: :published_entries },
+      { name: :same_table_ambiguity, truth: :association_n_plus_one, observed: :guidance_only,
+        model: -> { CorpusOwner }, association: :links, limitation: "two matching associations: exact advice unsupported" },
+      { name: :polymorphic, truth: :association_n_plus_one, observed: :guidance_only,
+        model: -> { CorpusOwner }, association: :notes, limitation: "polymorphic exact advice unsupported" },
+      { name: :through, truth: :association_n_plus_one, observed: :guidance_only,
+        model: -> { CorpusItem }, association: :notes, limitation: "through exact advice unsupported" },
+      { name: :count, truth: :repeated_aggregate, observed: :guidance_only, operation: :count,
+        workload: -> { CorpusOwner.order(:id).map { |owner| owner.items.count } } },
+      { name: :exists, truth: :repeated_existence, observed: :guidance_only, operation: :exists,
+        workload: -> { CorpusOwner.order(:id).map { |owner| owner.items.exists? } } },
+      { name: :scalar, truth: :repeated_scalar, observed: :guidance_only, operation: :scalar,
+        workload: -> { CorpusOwner.order(:id).map { |owner| owner.items.pluck(:id) } } },
+      { name: :identical_lookup, truth: :duplicate_read, observed: :candidate,
+        limitation: "known false positive: identical lookups are not distinguished from association loading",
+        workload: -> { 3.times.map { CorpusOwner.find_by!(code: "owner-0").id } } },
+      { name: :intentional_batches, truth: :intentional_repetition, observed: :guidance_only,
+        limitation: "known false positive: deliberate batching still triggers repeated-shape detection",
+        workload: -> { CorpusItem.in_batches(of: 2).map { |batch| batch.pluck(:id) } } },
+      { name: :query_cache, truth: :cached_duplicate_read, observed: :none,
+        workload: -> { CorpusOwner.cache { 3.times.map { CorpusOwner.find_by!(code: "owner-0").id } } }, physical: 1 },
+      { name: :preloaded, truth: :bounded_loading, observed: :none,
+        workload: -> { records(CorpusOwner.preload(:items), :items) }, physical: 2 },
+      { name: :below_threshold, truth: :association_n_plus_one, observed: :none,
+        limitation: "known false negative by configured threshold: only one child query",
+        workload: -> { records(CorpusOwner.limit(1), :items) }, physical: 2 }
+    ]
+  end
+
+  def records(relation, association)
+    relation.order(:id).map do |record|
+      value = record.public_send(association)
+      value.respond_to?(:to_ary) ? value.to_a.map(&:id).sort : value&.id
+    end
+  end
+end

--- a/test/test_accuracy_corpus.rb
+++ b/test/test_accuracy_corpus.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/accuracy_corpus"
+
+class TestAccuracyCorpus < Minitest::Test
+  include AndOneTestHelper
+
+  def setup
+    super
+    AccuracyCorpus.setup!
+    seed_data!
+  end
+
+  def teardown
+    Comment.delete_all
+    Post.delete_all
+    Author.delete_all
+    AccuracyCorpus.teardown!
+    super
+  end
+
+  AccuracyCorpus.scenarios.each do |scenario|
+    define_method("test_corpus_#{scenario.fetch(:name)}") do
+      diagnostic = "#{scenario[:name]}: truth=#{scenario[:truth]}, observed=#{scenario[:observed]}; #{scenario[:limitation]}"
+      workload = scenario[:workload] || -> { AccuracyCorpus.records(scenario[:model].call.all, scenario[:association]) }
+      detections = nil
+      baseline, before = measure do
+        detections = AndOne.scan { @result = workload.call }
+        @result
+      end
+      if scenario[:observed] == :none
+        assert_empty detections, diagnostic
+        assert_equal scenario[:physical], before, diagnostic
+      else
+        refute_empty detections, diagnostic
+        suggestions = detections.map { |detection| AndOne::AssociationResolver.resolve(detection, detection.raw_caller_strings) }
+        refute_includes suggestions, nil, diagnostic
+        assert_equal scenario[:observed] == :candidate, suggestions.all?(&:actionable?), diagnostic
+        assert_equal [scenario[:operation]], suggestions.map(&:operation).uniq, diagnostic if scenario[:operation]
+        verify_recommendation(scenario, suggestions, baseline, before, diagnostic) if scenario[:association] && scenario[:observed] == :candidate
+      end
+    end
+  end
+
+  def test_real_adapter_prepared_queries_capture_binds_and_preload_eliminates_repetition
+    connection = ActiveRecord::Base.connection
+    assert connection.prepared_statements, "#{connection.adapter_name} must exercise prepared queries"
+    events = []
+    subscriber = ->(*args) { events << args.last if args.last[:name] != "SCHEMA" }
+    detections = nil
+    ActiveRecord::Base.uncached do
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+        detections = AndOne.scan { AccuracyCorpus.records(CorpusOwner.all, :items) }
+      end
+    end
+    child_events = events.select { |payload| payload[:sql].include?("corpus_items") }
+    assert_equal 3, child_events.size
+    assert child_events.all? { |payload| !payload[:binds].empty? }, "expected real #{connection.adapter_name} bind metadata"
+    assert_equal 1, detections.size
+    assert_equal 3, detections.first.count
+    assert_equal ActiveRecord::Base.connection_db_config.adapter, detections.first.adapter
+    assert_empty(AndOne.scan { AccuracyCorpus.records(CorpusOwner.preload(:items), :items) })
+  end
+
+  private
+
+  def verify_recommendation(scenario, suggestions, baseline, before, diagnostic)
+    association = scenario.fetch(:association)
+    assert_equal [association], suggestions.map(&:association_name).uniq, diagnostic
+    %i[includes preload].each do |strategy|
+      assert_includes suggestions.first.fix_hint, ".#{strategy}(:#{association})", diagnostic
+      detections = nil
+      fixed, after = measure do
+        detections = AndOne.scan do
+          @result = AccuracyCorpus.records(scenario[:model].call.public_send(strategy, association), association)
+        end
+        @result
+      end
+      assert_equal baseline, fixed, "#{diagnostic}; #{strategy} changed results"
+      assert_operator after, :<, before, "#{diagnostic}; #{strategy} did not reduce physical queries"
+      assert_equal 2, after, diagnostic
+      assert_empty detections, diagnostic
+    end
+  end
+
+  def measure(&block)
+    count = 0
+    subscriber = lambda do |*args|
+      payload = args.last
+      count += 1 unless payload[:cached] || %w[SCHEMA TRANSACTION].include?(payload[:name])
+    end
+    result = ActiveRecord::Base.uncached do
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record", &block)
+    end
+    [result, count]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+require "logger" # Rails 7.0 expects Logger to be loaded before ActiveSupport.
 require "active_record"
 require "active_support"
 require "and_one"
@@ -9,13 +10,18 @@ require "minitest/autorun"
 require "tmpdir"
 require "fileutils"
 
-# Set up an in-memory SQLite database for testing
+# Service-backed jobs run the portable integration corpus only. DATABASE_URL
+# must point at a disposable test database: schema setup is destructive.
 ActiveRecord::Base.establish_connection(
-  adapter: "sqlite3",
-  database: ":memory:"
+  ENV.fetch("DATABASE_URL") { { adapter: "sqlite3", database: ":memory:", prepared_statements: true } }
 )
 
 ActiveRecord::Schema.define do
+  # Drop dependents first so service databases can be reused for another run.
+  drop_table :comments, if_exists: true
+  drop_table :posts, if_exists: true
+  drop_table :authors, if_exists: true
+
   create_table :authors, force: true do |t|
     t.string :name
   end

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -79,7 +79,9 @@ class TestThreadSafety < Minitest::Test
     errors = []
     threads = count.times.map do |i|
       Thread.new(i) do |idx|
-        block.call(idx, errors)
+        # Rails 7 keeps implicitly leased connections until explicitly released;
+        # return each worker's lease even when more workers than pool slots run.
+        ActiveRecord::Base.connection_pool.with_connection { block.call(idx, errors) }
       rescue StandardError => e
         errors << "Thread #{idx}: #{e.class}: #{e.message}\n#{e.backtrace.first(3).join("\n")}"
       end


### PR DESCRIPTION
## Summary
- Add explicit Ruby/Rails boundary and intermediate CI jobs, plus PostgreSQL 16/MySQL 8.0 prepared-query integration jobs.
- Add a 17-scenario labeled accuracy corpus covering supported recommendations, complex associations, cache/batching, and explicit known false positives/negatives. Execute both recommended fixes and compare results and physical query counts.
- Keep dependency resolution separate from the primary lockfile; document local reproduction and matrix limits.
- Address compatibility failures uncovered by the matrix: Rails 7 JSON dependency selection, Logger load order, and returning stress-test worker connection leases.

Closes #19
Closes #20

## Validation
- Default Ruby 4.0.6 / Rails 8.1.2: 266 tests, 1321 assertions; RuboCop clean.
- Ruby 3.2.11 / Rails 7.0.10: 266 tests, 1321 assertions; RuboCop clean.
- All seven GitHub Actions jobs passed: full tests + RuboCop on Ruby/Rails 3.2/7.0, 3.3/7.2, and 4.0/8.1; 18 corpus/prepared-query tests on PostgreSQL 16 and MySQL 8.0 at both Rails boundaries.
- PostgreSQL 16 / Ruby 3.2 / Rails 7.0 also passed locally: 18 tests, 180 assertions.
- The local MySQL native extension crashed during ActiveRecord schema setup; both MySQL jobs passed in the intended Ubuntu CI environment.

These two issues are combined because the portable accuracy corpus is the shared integration workload for the adapter matrix; no detection-policy/classification changes are included.
