### PR TITLE
Make toast injection conservative and CSP-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,11 @@ AndOne.dev_toast_position = :bottom_right  # :top_right (default), :top_left, :b
 AndOne.dev_toast = false                   # disable entirely
 ```
 
-The toast only appears on HTML responses with a 200 status, so it won't interfere with API endpoints, redirects, or error pages.
+The toast only transforms complete `text/html` responses with status 200 and a Rack `to_ary` body (including ordinary Rails renders). HEAD, API, redirect, error, encoded/compressed, streaming, file/download, and partial responses are left untouched. Place AndOne inside compression middleware to inject before compression. Transformed responses lose Content-Length and validators/digests; untouched content keeps its metadata. Rack bodies own cleanup in `to_ary`, including on conversion errors; AndOne does not enumerate arbitrary bodies or close converted bodies a second time.
+
+With a Content-Security-Policy header (including report-only) or CSP meta tag, the toast becomes an unstyled, script-free native `<details>` notice with a dashboard link. It does not auto-dismiss or use the position setting, and never requires `unsafe-inline` or changes your policy.
+
+**SQL coverage:** scanning ends when the application returns its Rack response, before lazy body enumeration. Queries executed by streaming/lazy bodies are not captured by this middleware; use an explicit scan within that workload if needed.
 
 ### Dashboard
 

--- a/lib/and_one/dev_toast.rb
+++ b/lib/and_one/dev_toast.rb
@@ -25,12 +25,29 @@ module AndOne
 
     # Injects toast HTML/JS/CSS before </body> in an HTML response.
     # Returns the modified body string, or the original if not injectable.
-    def inject(body_string, detections)
+    def inject(body_string, detections, script_free: false)
       return body_string if detections.nil? || detections.empty?
-      return body_string unless body_string.include?("</body>")
+      return body_string unless body_string.match?(%r{</body\s*>}i)
 
-      toast_html = render_toast(detections)
-      body_string.sub("</body>", "#{toast_html}\n</body>")
+      # A meta-delivered policy is just as binding as a response header.
+      script_free ||= body_string.match?(/<meta\b[^>]*content-security-policy/i)
+      toast_html = script_free ? render_fallback(detections) : render_toast(detections)
+      body_string.sub(%r{</body\s*>}i) { |closing| "#{toast_html}\n#{closing}" }
+    end
+
+    def render_fallback(detections)
+      summaries = detections.first(5).map do |detection|
+        "<li>#{detection.count}x <code>#{escape(detection.table_name || "unknown")}</code></li>"
+      end
+      <<~HTML
+        <aside id="and-one-toast" role="status" aria-live="polite">
+          <details>
+            <summary>AndOne: #{detections.size} N+1 findings detected</summary>
+            <ul>#{summaries.join}</ul>
+            <a href="#{DevUI::MOUNT_PATH}">View Dashboard →</a>
+          </details>
+        </aside>
+      HTML
     end
 
     def render_toast(detections)

--- a/lib/and_one/middleware.rb
+++ b/lib/and_one/middleware.rb
@@ -20,30 +20,37 @@ module AndOne
       status = headers = body = nil
       detections = AndOne.scan { status, headers, body = @app.call(env) }
 
-      if AndOne.dev_toast && detections&.any? && html_response?(headers) && status == 200
-        body = inject_toast(body, detections)
-        # Recalculate Content-Length since we modified the body
-        headers.delete("content-length")
-        headers.delete("Content-Length")
-      end
+      headers, body = inject_toast(headers, body, detections) if AndOne.dev_toast && detections&.any? && injectable?(env, status, headers, body)
 
       [status, headers, body]
     end
 
     private
 
-    def html_response?(headers)
-      content_type = headers["content-type"] || headers["Content-Type"]
-      content_type&.include?("text/html")
+    def injectable?(env, status, headers, body)
+      normalized = headers.transform_keys(&:downcase)
+      status == 200 && env["REQUEST_METHOD"] != "HEAD" &&
+        normalized["content-type"].to_s.split(";").first.to_s.strip.downcase == "text/html" &&
+        !normalized.key?("content-encoding") && !normalized.key?("transfer-encoding") &&
+        !normalized.key?("content-range") && !normalized.key?("content-disposition") &&
+        !normalized.key?("x-sendfile") && !normalized.key?("x-accel-redirect") &&
+        !env["rack.hijack_io"] && !headers.key?("rack.hijack") &&
+        body.respond_to?(:to_ary) && !body.respond_to?(:to_path)
     end
 
-    def inject_toast(body, detections)
-      full_body = +""
-      body.each { |chunk| full_body << chunk }
-      body.close if body.respond_to?(:close)
+    def inject_toast(headers, body, detections)
+      # Rack permits eager conversion only through to_ary. That method owns
+      # closing the original body (including on failure); do not close it twice.
+      chunks = body.to_ary
+      full_body = chunks.join
+      csp = headers.keys.any? { |key| key.downcase.start_with?("content-security-policy") }
+      injected = DevToast.inject(full_body, detections, script_free: csp)
+      return [headers, chunks] if injected.equal?(full_body)
 
-      injected = DevToast.inject(full_body, detections)
-      [injected]
+      headers = headers.reject do |key, _value|
+        %w[content-length etag last-modified content-md5 digest content-digest repr-digest accept-ranges].include?(key.downcase)
+      end
+      [headers, [injected]]
     end
   end
 end

--- a/test/test_rails_configuration.rb
+++ b/test/test_rails_configuration.rb
@@ -81,6 +81,27 @@ class TestRailsConfiguration < Minitest::Test
     RUBY
   end
 
+  def test_toast_in_real_rails_middleware_stack
+    boot("development", initializer: "AndOne.logfile = nil; Rails.application.config.hosts.clear",
+                        before: 'ENV["DATABASE_URL"] = "sqlite3::memory:"', assertions: <<~RUBY)
+                          class ToastController < ActionController::Base
+                            def index
+                              3.times do
+                                ActiveSupport::Notifications.instrument("sql.active_record", sql: "SELECT * FROM posts WHERE id = 1", name: "Post Load")
+                              end
+                              response.set_header("Content-Security-Policy", "default-src 'none'")
+                              render html: "<html><body>Rails page</body></html>".html_safe
+                            end
+                          end
+                          Rails.application.routes.draw { get "/toast", to: "toast#index" }
+                          response = Rack::MockRequest.new(Rails.application).get("http://localhost/toast")
+                          abort "status: \#{response.status} \#{response.body}" unless response.status == 200
+                          abort "missing fallback" unless response.body.include?("<details>") && response.body.include?("posts")
+                          abort "inline script" if response.body.include?("<script>")
+                          abort "changed CSP" unless response["content-security-policy"] == "default-src 'none'"
+                        RUBY
+  end
+
   def test_explicit_production_enable
     boot("production", initializer: "AndOne.enabled = true; AndOne.raise_on_detect = true", assertions: <<~RUBY)
       abort "disabled" unless AndOne.enabled? && AndOne.raise_on_detect

--- a/test/test_toast_contract.rb
+++ b/test/test_toast_contract.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rack/mock"
+require "rack/lint"
+require "rack/deflater"
+
+class TestToastContract < Minitest::Test
+  include AndOneTestHelper
+
+  # A Rack-compliant buffered body owns cleanup in to_ary, even on errors.
+  class BufferedBody
+    attr_reader :closes
+
+    def initialize(fail: false)
+      @fail = fail
+      @closes = 0
+    end
+
+    def each
+      raise "enumeration failed" if @fail
+
+      yield "<html><body>OK</body></html>"
+    end
+
+    def to_ary
+      chunks = []
+      each { |chunk| chunks << chunk }
+      chunks
+    ensure
+      close
+    end
+
+    def close
+      @closes += 1
+    end
+  end
+
+  def setup
+    super
+    AndOne.dev_toast = true
+  end
+
+  def app(body, headers = { "content-type" => "text/html" }, status = 200)
+    lambda do |_env|
+      3.times { Post.where(id: 1).to_a }
+      [status, headers, body]
+    end
+  end
+
+  def request(application, method = "GET")
+    application.call(Rack::MockRequest.env_for("/", method: method))
+  end
+
+  def test_buffered_body_closes_once_and_passes_rack_lint
+    original = BufferedBody.new
+    response = Rack::MockRequest.new(Rack::Lint.new(AndOne::Middleware.new(app(original)))).get("/")
+    assert_includes response.body, "and-one-toast"
+    assert_equal 1, original.closes
+  end
+
+  def test_conversion_error_closes_once_and_leaves_scan_stopped
+    original = BufferedBody.new(fail: true)
+    error = assert_raises(RuntimeError) { request(AndOne::Middleware.new(app(original))) }
+    assert_equal "enumeration failed", error.message
+    assert_equal 1, original.closes
+    refute AndOne.scanning?
+  end
+
+  def test_lazy_and_streaming_bodies_are_not_consumed
+    [Object.new, Object.new].each_with_index do |body, index|
+      body.define_singleton_method(index.zero? ? :each : :call) { |*| raise "consumed" }
+      body.define_singleton_method(:close) { raise "closed" }
+      assert_same body, request(AndOne::Middleware.new(app(body))).last
+    end
+  end
+
+  def test_lazy_sql_is_outside_scan
+    body = Object.new
+    body.define_singleton_method(:each) do |&block|
+      3.times { Post.where(id: 1).to_a }
+      block.call("<body>OK</body>")
+    end
+    middleware = AndOne::Middleware.new(->(_) { [200, { "content-type" => "text/html" }, body] })
+    result = request(middleware).last
+    result.each { |chunk| refute_includes chunk, "and-one-toast" }
+    assert_empty AndOne.aggregate.detections
+  end
+
+  def test_ineligible_responses_preserve_body_and_headers
+    variants = [
+      [200, "HEAD", {}], [302, "GET", {}], [500, "GET", {}], [204, "GET", {}],
+      [200, "GET", { "content-type" => "application/json" }],
+      [200, "GET", { "content-type" => "text/htmlish" }],
+      [200, "GET", { "Content-Encoding" => "gzip" }],
+      [200, "GET", { "transfer-encoding" => "chunked" }],
+      [200, "GET", { "content-range" => "bytes 0-10/20" }],
+      [200, "GET", { "content-disposition" => "attachment" }]
+    ]
+    variants.each do |status, method, extra|
+      headers = { "content-type" => "text/html", "etag" => "old" }.merge(extra)
+      body = BufferedBody.new
+      response = request(AndOne::Middleware.new(app(body, headers, status)), method)
+      assert_same headers, response[1]
+      assert_same body, response[2]
+      assert_equal 0, body.closes
+    end
+  end
+
+  def test_compression_on_either_side_of_middleware
+    html = ["<body>OK</body>"]
+    inner = AndOne::Middleware.new(Rack::Deflater.new(app(html)))
+    outer = Rack::Deflater.new(AndOne::Middleware.new(app(html)))
+    [inner, outer].each_with_index do |stack, index|
+      response = Rack::MockRequest.new(stack).get("/", "HTTP_ACCEPT_ENCODING" => "gzip")
+      assert_equal "gzip", response["content-encoding"]
+      decoded = Zlib::GzipReader.new(StringIO.new(response.body)).read
+      assert_equal index == 1, decoded.include?("and-one-toast")
+    end
+  end
+
+  def test_metadata_removed_only_when_transformed_and_frozen_headers_supported
+    headers = { "content-type" => "text/html", "Content-Length" => "20", "ETag" => "old",
+                "Last-Modified" => "yesterday", "Digest" => "old", "content-md5" => "old",
+                "content-digest" => "old", "repr-digest" => "old", "accept-ranges" => "bytes" }.freeze
+    changed = request(AndOne::Middleware.new(app(["<BODY>OK</BODY>"], headers)))
+    assert_equal({ "content-type" => "text/html" }, changed[1])
+    unchanged = request(AndOne::Middleware.new(app(["fragment"], headers)))
+    assert_same headers, unchanged[1]
+    assert_equal ["fragment"], unchanged[2]
+  end
+
+  def test_strict_csp_uses_native_details_without_active_assets
+    policy = "default-src 'none'; script-src 'none'; style-src 'none'"
+    headers = { "content-type" => "text/html", "Content-Security-Policy" => policy }
+    response = request(AndOne::Middleware.new(app(["<body>OK</body>"], headers)))
+    assert_equal policy, response[1]["Content-Security-Policy"]
+    assert_fallback response[2].join
+    meta = %(<head><meta http-equiv="Content-Security-Policy" content="#{policy}"></head><body>OK</body>)
+    assert_fallback request(AndOne::Middleware.new(app([meta])))[2].join
+  end
+
+  def test_ignored_findings_do_not_produce_a_toast
+    AndOne.ignore_queries = [/posts/]
+    body = ["<body>OK</body>"]
+    assert_same body, request(AndOne::Middleware.new(app(body))).last
+  end
+
+  private
+
+  def assert_fallback(html)
+    assert_includes html, "<details>"
+    assert_includes html, "posts"
+    assert_includes html, AndOne::DevUI::MOUNT_PATH
+    refute_match(/<script|<style|onclick=|style=/i, html)
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #16.

- Transform only buffered, complete HTML Rack responses; leave streaming, compressed, HEAD, downloads and ineligible responses untouched.
- Respect Rack to_ary cleanup ownership and remove affected validators only after transformation.
- Use a native, script-free details notice under header/meta CSP without weakening policy.
- Document lazy SQL coverage and compression ordering.

## Validation
- `bundle exec rake test`: 276 runs, 1390 assertions, no failures
- `bundle exec rubocop -a`: clean after corrections
- New Rack::Lint, compression-ordering, cleanup/error, strict-CSP and real Rails middleware-stack regressions.