### PR TITLE
Preserve finding sessions and bound aggregate storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Fixed
 
+- Preserve shared aggregate/log findings across boots, isolate environment/test sessions, and provide explicit reset and bounded stale-session cleanup (#8).
+- Default to bounded in-memory aggregates, opt into shared file storage, batch each scan into one transaction, and diagnose persistence failures without disrupting application work or N+1 enforcement (#9).
+
 - Honor Rails application initializer paths, formats, and explicit disable settings before service I/O; rebuild cached services when their configuration changes between scans (#7).
 - Flush logfile findings before exit, retain a bounded retry buffer on failures, and keep callbacks outside output locks without suppressing N+1 enforcement (#17).
 - Recognize case-insensitive reads and read CTEs conservatively, preserve ordered stack frames, and attribute/isolate SQL using the emitting connection (#5).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AndOne stays completely invisible until it detects an N+1 query — then it poin
 - **Auto-raises in test** — N+1s fail your test suite by default
 - **Background job support** — ActiveJob (`around_perform`) and Sidekiq server middleware, with double-scan protection
 - **Ignore file** — `.and_one_ignore` with `gem:`, `path:`, `query:`, and `fingerprint:` rules
-- **Automatic deduplication** — each unique N+1 is reported once per server session with occurrence counts, shared across all Puma workers via disk-based storage
+- **Bounded deduplication** — occurrence counts with in-memory storage by default and opt-in shared, session-scoped file storage
 - **Test matchers** — Minitest (`assert_no_n_plus_one`) and RSpec (`expect { }.not_to cause_n_plus_one`)
 - **Dev toast notifications** — in-page toast on every page that triggers an N+1, with a link to the dashboard
 - **Dev UI dashboard** — browse `/__and_one` in development for a live N+1 overview
@@ -71,7 +71,7 @@ end
 puts "Detected #{detections.size} repeated-query patterns"
 ```
 
-Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans persist findings under `tmp/and_one` by default; set `aggregate_path` before the first scan to change it. `require "and_one"` is safe before or after loading Rails.
+Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans keep bounded findings in memory by default; set `aggregate_store = :file` before the first scan for process sharing. `require "and_one"` is safe before or after loading Rails.
 
 ## Capture coverage and limits
 
@@ -177,7 +177,7 @@ This is especially useful for **N+1s coming from gems** where you can't add `.in
 
 ## Deduplication
 
-In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique issue (query shape + application origin + connection context) is reported only once per server session. Subsequent occurrences at that location are silently counted; the same SQL shape at a different location remains visible as a separate issue.
+In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique issue (query shape + application origin + connection context) is reported only once while retained in the aggregate (per process by default, or across cooperating processes with file storage). Subsequent occurrences at that location are silently counted; the same SQL shape at a different location remains visible as a separate issue.
 
 Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan. Test matchers do not report or consume first-occurrence deduplication.
 
@@ -326,8 +326,15 @@ AndOne.configure do |config|
   # Options: :top_right, :top_left, :bottom_right, :bottom_left
   config.dev_toast_position = :top_right
 
-  # Aggregate storage path (default: Rails.root/tmp/and_one)
-  config.aggregate_path = Rails.root.join("tmp", "and_one").to_s
+  # Opt in to process sharing (default: bounded in-memory storage)
+  config.aggregate_store = :file
+
+  # Optional exact custom directory; also opts into file storage.
+  # Custom paths bypass automatic environment/session isolation.
+  # config.aggregate_path = Rails.root.join("tmp", "my_findings").to_s
+
+  # Raise storage errors instead of diagnosing them (default: false)
+  config.storage_strict = false
 
   # Path to ignore file (default: Rails.root/.and_one_ignore)
   config.ignore_file_path = Rails.root.join(".and_one_ignore").to_s
@@ -347,8 +354,9 @@ AndOne.configure do |config|
   # Custom backtrace cleaner
   config.backtrace_cleaner = Rails.backtrace_cleaner
 
-  # Log all unique findings to a file (default: "log/and_one.log", nil to disable)
-  config.logfile = "log/and_one.log"
+  # Rails dev/test default: findings.log in the environment/session directory.
+  # A custom path bypasses session isolation; nil disables file output.
+  config.logfile = :session
 
   # Logfile format: :text or :json (default: :text)
   config.logfile_format = :text
@@ -364,9 +372,9 @@ end
 
 ### Configuration lifecycle
 
-Rails defaults are applied before `config/initializers`, without overwriting explicitly assigned settings (including `logfile = nil` or `false`). Service setup and middleware registration happen after those initializers. Development/test enable scanning and a logfile at `Rails.root/log/and_one.log`; only test raises by default. Production is disabled by default, but can be explicitly enabled.
+Rails defaults are applied before `config/initializers`, without overwriting explicitly assigned settings (including `logfile = nil` or `false`). Service setup and middleware registration happen after those initializers. Development/test enable scanning and a session-scoped logfile under `Rails.root/tmp/and_one/sessions`; only test raises by default. Production is disabled by default, but can be explicitly enabled.
 
-Configure before scanning. Between scans, changing `aggregate_path` or `ignore_file_path` rebuilds the corresponding cached service on next access. Changing `logfile` or `logfile_format` first flushes the old writer, then replaces it; a flush failure raises and rejects that configuration change. Do not reconfigure while requests/jobs are running. Other settings are read by subsequent scans/reports. Boot still resets the configured aggregate and truncates the configured logfile; shared-session lifecycle improvements are tracked separately in #8.
+Configure before scanning. Between scans, changing `aggregate_path`, `aggregate_store`, `storage_strict`, or `ignore_file_path` rebuilds the corresponding cached service on next access. Changing `logfile` or `logfile_format` first flushes the old writer, then replaces it; a flush failure raises and rejects that configuration change. Do not reconfigure while requests/jobs are running. Other settings are read by subsequent scans/reports. Boot never resets the aggregate or truncates the logfile. See [storage and session lifecycle](docs/storage.md) for defaults, explicit resets, bounded cleanup, limits, and migration.
 
 ### Logfile delivery and failures
 
@@ -374,7 +382,7 @@ New, ignore-filtered findings are flushed synchronously after each reporting sca
 
 Format/open/write failures retain pending entries. Cooperating processes use file locks; failed partial appends are rolled back when the filesystem permits. The retry buffer holds at most 1,000 unique findings; overflow rejects the new batch with a rate-limited diagnostic during reporting, preserving previously accepted entries. Newly rejected findings are not automatically redelivered because aggregate deduplication has already occurred. This is best-effort delivery, not crash durability or exactly-once delivery; shutdown, rollback failure, or buffer exhaustion can lose findings.
 
-Callbacks run outside output locks and may reenter scanning. Callback and output `StandardError`s are diagnosed on stderr at most once per minute and do not fail application work or suppress configured `NPlus1Error` enforcement. `NPlus1Error` itself is always propagated, including from a nested callback scan. Callbacks are not retried. Explicit writer `record`/`flush!` calls still raise on failure. Aggregate persistence failures are a separate policy (tracked in #9).
+Callbacks run outside output locks and may reenter scanning. Callback and output `StandardError`s are diagnosed on stderr at most once per minute and do not fail application work or suppress configured `NPlus1Error` enforcement. `NPlus1Error` itself is always propagated, including from a nested callback scan. Callbacks are not retried. Explicit writer `record`/`flush!` calls still raise on failure. Aggregate persistence failures also default to non-disruptive, rate-limited diagnostics; `storage_strict = true` opts into propagation. See [storage policy](docs/storage.md).
 
 ## Manual Scanning
 

--- a/bench/aggregate_storage.rb
+++ b/bench/aggregate_storage.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# bundle exec ruby bench/aggregate_storage.rb
+# Reports retained growth and 20 scan transactions, not a CI timing assertion.
+require "bundler/setup"
+require "and_one"
+require "tmpdir"
+
+puts "store,history,retained,bytes,20_scans_seconds"
+%i[memory file].each do |kind|
+  [10, 100, 1000].each do |history|
+    Dir.mktmpdir("and_one_benchmark") do |path|
+      aggregate = AndOne::Aggregate.new(path: kind == :file ? path : nil, strict: true)
+      findings = Array.new(history) do |index|
+        AndOne::Detection.new(queries: ["SELECT * FROM posts WHERE id = #{index}"], count: 10,
+                              raw_caller_strings: ["app/example.rb:#{index + 1}"])
+      end
+      findings.each_slice(10) { |batch| aggregate.record_many(batch) }
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      20.times { aggregate.record_many(findings.last(10)) }
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      bytes = kind == :file ? File.size(File.join(path, "aggregate.json")) : "n/a"
+      puts [kind, history, aggregate.size, bytes, elapsed.round(4)].join(",")
+    end
+  end
+end

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,143 @@
+# Aggregate storage and session lifecycle
+
+## Defaults and sharing
+
+The aggregate defaults to **bounded, process-local memory**, including in Rails.
+No aggregate directory is created until file storage is actually used. Memory
+history disappears on exit; forked workers inherit a snapshot, not shared counts.
+To share counts and dashboard findings across a server, console, and job workers:
+
+```ruby
+AndOne.configure do |config|
+  config.aggregate_store = :file
+end
+```
+
+The file store and Rails development/test default logfile use
+`<application root>/tmp/and_one/sessions/<session key>/`. Outside Rails, the
+application root is the working directory. The key hashes the environment and
+session ID; it is an isolation key, not a security boundary.
+
+- Environment is Rails.env, then RAILS_ENV/RACK_ENV, then development.
+- Development uses a stable `default` ID. Independently booting a console,
+  runner, or worker joins the same findings without deleting anything.
+- Test uses a random ID allocated when AndOne is loaded. Independent test boots
+  are isolated; preloaded/forked workers inherit the same ID.
+- Set **`AND_ONE_SESSION=ci-run-123` before boot** on every cooperating process
+  to share an independent test run or select a fresh development session. Use a
+  unique value per CI run, not per worker. Environment remains part of the key,
+  even with an explicit ID. Do not change session environment variables live.
+
+Rails development/test default `logfile` is `:session` (resolve its actual path
+with `AndOne.logfile`). Standalone applications still default to no logfile.
+`logfile = nil` or `false` disables it. Production remains disabled by default.
+There are no destructive boot actions, timers, or automatic shutdown resets.
+
+An explicit `aggregate_path` selects file storage at that **exact directory**,
+regardless of `aggregate_store`. An explicit logfile string also uses that exact
+path. These overrides deliberately bypass automatic session/environment
+isolation: the application owns their naming, retention, and sharing policy.
+Set `aggregate_path = nil` and `aggregate_store = :memory` to return to memory.
+Configure services only between scans, with other writers stopped.
+
+## Reset and cleanup ownership
+
+No booting process owns the right to erase another process's findings. Reset is
+an explicit operator action:
+
+```ruby
+AndOne.aggregate.reset! # only the currently configured aggregate
+AndOne.reset_session!   # flush pending logfile output, reset aggregate, truncate logfile
+AndOne.session.cleanup!(older_than: 7 * 86_400, limit: 100)
+```
+
+Stop/quiesce cooperating writers before resetting both sinks. Reset operations
+are individually locked, not one atomic transaction across aggregate and log;
+a running scan can repopulate findings afterward. Reset never deletes other
+session directories. Custom paths are reset as explicitly configured.
+
+Cleanup is opt-in maintenance. Each call examines at most `limit` directory
+entries; repeated calls on the same Session instance continue through the
+registry. It only removes stale, inactive session directories, not custom paths.
+Age is based on the latest directory, aggregate, logfile, or lease modification.
+Live processes hold shared leases (also inherited across fork); cleanup requires
+an exclusive nonblocking lease. A registry lock coordinates joining and cleanup.
+No multi-host/network-filesystem locking guarantees are made. Sessions are not
+cleaned automatically, so schedule maintenance if using many test-run IDs.
+Logfiles within a long-lived active session still need operator rotation/reset.
+
+## Retention, cost, and failure policy
+
+The public `record`, `detections`, `size`, `empty?`, `summary`, and `reset!` API is
+preserved. `record_many(detections)` returns the new findings and commits the
+entire scan in **one store transaction**. Stores implement `transaction` and
+`reset!`; the Aggregate facade owns serialization, limits, and failure policy.
+
+Both stores retain at most **100 unique issues**, evicting the least recently
+observed issue. Evicted issues can be reported again; counts are totals only for
+the retained history, not lifetime totals. Each retained first occurrence holds:
+
+- at most 5 SQL samples, each at most 2,048 UTF-8 bytes;
+- at most 20 backtrace frames, each at most 256 UTF-8 bytes;
+- bounded adapter/connection labels, original count, and stable identities.
+
+Truncation does not recompute the original fingerprint or issue ID. Detection
+thresholds, scan results, and ignores operate on the original capture, before
+aggregate sample limiting. Historical valid documents are trimmed on access.
+
+The file store reads at most **4 MiB + 1 byte**, rejects larger documents, and
+never commits a document exceeding 4 MiB (including JSON escaping). It locks,
+reads, and atomically replaces a single local JSON file per scan. Work is bounded
+by the retained history, but this is still an O(retained entries) rewrite, not a
+high-throughput database. Atomic rename prevents partial documents; there is no
+fsync/power-loss durability guarantee. New aggregate/lock/log files use 0600;
+new session/store directories use 0700. Existing permissions are not changed.
+
+**SQL samples are still raw and may contain secrets.** Size limits and file
+permissions are not redaction or dashboard authentication; that remains #10.
+Do not expose this storage or dashboard to untrusted users.
+
+By default, filesystem errors, corrupt/invalid JSON, oversized documents, and
+failed writes produce a stderr diagnostic at most once per minute per Aggregate
+instance, showing only the exception class. They do not fail application work
+or suppress configured N+1 enforcement. A failed update treats every finding as
+new for output; duplicates may be emitted and counts for that scan are lost.
+Failed reads return an empty snapshot. Corrupt documents are **not silently
+replaced**: fix the underlying problem, or explicitly `aggregate.reset!` to
+recover. Interrupted temporary writes are removed on ordinary exceptions; an
+abrupt process kill may leave a bounded `.tmp` file, overwritten on the next
+write. There is no unbounded retry queue or invisible in-memory fallback.
+
+`config.storage_strict = true` propagates storage errors instead (useful for
+storage debugging/tests; a storage exception can precede N+1 enforcement).
+Direct `Aggregate.new(path: ..., strict: true)` supports the same policy.
+
+## Upgrade notes
+
+Previous versions used `tmp/and_one/aggregate.json`, `log/and_one.log`, and
+reset/truncated them on boot. They are no longer touched by defaults. Archive or
+remove those old files explicitly. To keep the previous aggregate location,
+configure `aggregate_path` explicitly; valid historical entries retain their
+identities but are subject to the new bounds. To keep the old logfile location,
+configure it explicitly, accepting that it is no longer isolated by session.
+
+## Reproducible growth benchmark
+
+Run `bundle exec ruby bench/aggregate_storage.rb`. It seeds 10, 100, and 1,000
+unique historical findings, then measures 20 scans of 10 findings. Example on
+Ruby 4.0.6, local filesystem (seconds vary; no wall-clock CI assertions):
+
+```text
+store,history,retained,bytes,20_scans_seconds
+memory,10,10,n/a,0.0101
+memory,100,100,n/a,0.0871
+memory,1000,100,n/a,0.0851
+file,10,10,3462,0.0404
+file,100,100,34693,0.1242
+file,1000,100,34912,0.1246
+```
+
+Retained entries and rewrite size plateau at the limit. Regression tests assert
+bounds, transaction counts, process-safe counts, independent Rails boot/fork
+lifecycles, malformed data preservation/reset, permission/open failures, and
+interrupted writes, rather than timing thresholds.

--- a/lib/and_one.rb
+++ b/lib/and_one.rb
@@ -11,6 +11,7 @@ require_relative "and_one/test_capture"
 require_relative "and_one/query_capture"
 require_relative "and_one/reporting"
 require_relative "and_one/configuration"
+require_relative "and_one/session"
 
 module AndOne
   class NPlus1Error < StandardError; end
@@ -24,6 +25,7 @@ module AndOne
   # across Puma threads.
   @singleton_mutex = Mutex.new
   @report_mutex = Mutex.new
+  @session_mutex = Mutex.new
 
   class << self
     attr_accessor :enabled, :raise_on_detect, :backtrace_cleaner,
@@ -90,7 +92,10 @@ module AndOne
 
     def aggregate
       @singleton_mutex.synchronize do
-        @aggregate ||= Aggregate.new(path: aggregate_path)
+        @aggregate ||= begin
+          store = AggregateStore::FileStore.new(aggregate_path || session) if aggregate_path || aggregate_store == :file
+          Aggregate.new(store: store, strict: storage_strict)
+        end
       end
     end
 
@@ -98,6 +103,7 @@ module AndOne
       return nil unless logfile
 
       @singleton_mutex.synchronize do
+        session.activate! if @logfile == :session
         @logfile_writer ||= LogfileWriter.new(
           path: logfile,
           format: logfile_format || :text

--- a/lib/and_one/aggregate.rb
+++ b/lib/and_one/aggregate.rb
@@ -3,14 +3,15 @@
 require "json"
 require "fileutils"
 require "time"
+require_relative "aggregate_store"
 
 module AndOne
   # Tracks unique N+1 detections across requests/jobs in a server session.
   # Each unique N+1 (by issue identity) is only reported once.
   # Subsequent occurrences are silently counted.
   #
-  # Data is stored on disk (JSON) so detections are shared across all Puma
-  # workers in multi-process deployments. File locking ensures consistency.
+  # Memory storage is the default. An explicit path selects shared JSON storage.
+  # Both stores retain only a bounded least-recently-observed history.
   #
   # The aggregate can be queried at any time:
   #   AndOne.aggregate.summary    # => formatted string
@@ -20,61 +21,53 @@ module AndOne
   class Aggregate
     Entry = Struct.new(:detection, :occurrences, :first_seen_at, :last_seen_at)
 
-    def initialize(path: nil)
-      @dir = path || default_dir
-      @data_path = File.join(@dir, "aggregate.json")
-      @lock_path = File.join(@dir, "aggregate.lock")
-      @mutex = Mutex.new
-      FileUtils.mkdir_p(@dir)
+    MAX_ENTRIES = 100
+    MAX_SAMPLES = 5
+    MAX_SQL_BYTES = 2048
+    MAX_FRAMES = 20
+    MAX_FRAME_BYTES = 256
+
+    def initialize(path: nil, store: nil, strict: false)
+      @store = store || (path ? AggregateStore::FileStore.new(path) : AggregateStore::Memory.new)
+      @strict = strict
+      @warning_mutex = Mutex.new
     end
 
     # Record a detection. Returns true if this is a NEW unique detection
     # (first time seeing this issue identity), false if it's a repeat.
-    def record(detection)
-      fp = detection.issue_id
+    def record(detection) # rubocop:disable Naming/PredicateMethod -- public compatibility API
+      record_many([detection]).include?(detection)
+    end
 
-      with_lock do
-        data = read_data
-
-        if data.key?(fp)
-          data[fp]["occurrences"] += 1
-          data[fp]["last_seen_at"] = Time.now.iso8601
-          write_data(data)
-          false
-        else
-          data[fp] = {
-            "detection" => serialize_detection(detection),
-            "occurrences" => 1,
-            "first_seen_at" => Time.now.iso8601,
-            "last_seen_at" => Time.now.iso8601
-          }
-          write_data(data)
-          true
+    # One transaction per scan. On failure all findings remain reportable.
+    def record_many(detections)
+      safely(default: detections) do
+        @store.transaction do |data|
+          normalize_data!(data)
+          detections.select { |detection| record_new?(data, detection) }
         end
       end
     end
 
     def detections
-      with_lock do
-        data = read_data
-        data.each_with_object({}) do |(fp, entry_data), result|
-          result[fp] = deserialize_entry(entry_data)
+      safely(default: {}) do
+        @store.transaction do |data|
+          normalize_data!(data)
+          data.transform_values { |entry| deserialize_entry(entry) }
         end
       end
     end
 
     def size
-      with_lock { read_data.size }
+      detections.size
     end
 
     def empty?
-      with_lock { read_data.empty? }
+      detections.empty?
     end
 
     def reset!
-      with_lock do
-        FileUtils.rm_f(@data_path)
-      end
+      safely(default: nil) { @store.reset! }
     end
 
     def summary
@@ -103,43 +96,61 @@ module AndOne
 
     private
 
-    def with_lock
-      @mutex.synchronize do
-        File.open(@lock_path, File::RDWR | File::CREAT) do |lock|
-          lock.flock(File::LOCK_EX)
-          yield
+    def record_new?(data, detection)
+      key = detection.issue_id
+      existing = data.delete(key)
+      now = Time.now.iso8601
+      data[key] = if existing
+                    existing.merge("occurrences" => existing.fetch("occurrences") + 1, "last_seen_at" => now)
+                  else
+                    { "detection" => serialize_detection(detection), "occurrences" => 1,
+                      "first_seen_at" => now, "last_seen_at" => now }
+                  end
+      data.shift while data.size > MAX_ENTRIES
+      !existing
+    end
+
+    def normalize_data!(data)
+      normalized = data.values.last(MAX_ENTRIES).to_h do |entry|
+        detection = deserialize_entry(entry).detection
+        raise IOError, "Invalid occurrence count" unless entry["occurrences"].is_a?(Integer) && entry["occurrences"].positive?
+
+        bounded_entry = { "detection" => serialize_detection(detection), "occurrences" => entry["occurrences"],
+                          "first_seen_at" => parse_time(entry["first_seen_at"])&.iso8601,
+                          "last_seen_at" => parse_time(entry["last_seen_at"])&.iso8601 }
+        [detection.issue_id, bounded_entry]
+      end
+      data.replace(normalized)
+    end
+
+    def safely(default:)
+      yield
+    rescue StandardError => e
+      raise if @strict
+
+      @warning_mutex.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if !@last_warning || now - @last_warning >= 60
+          @last_warning = now
+          warn "AndOne aggregate storage failed (#{e.class}); findings were not persisted"
         end
       end
+      default
     end
 
-    def read_data
-      return {} unless File.exist?(@data_path)
-
-      JSON.parse(File.read(@data_path)).each_with_object({}) do |(_key, entry), data|
-        # Upgrade legacy shape-keyed entries using the one location they retained.
-        # Already-persisted issue IDs do not depend on the reader's application root.
-        entry["detection"] = serialize_detection(deserialize_entry(entry).detection) unless entry["detection"]["issue_id"]
-        data[entry["detection"]["issue_id"]] = entry
-      end
-    rescue JSON::ParserError
-      {}
-    end
-
-    def write_data(data)
-      tmp_path = "#{@data_path}.tmp"
-      File.write(tmp_path, JSON.generate(data))
-      File.rename(tmp_path, @data_path)
+    def bounded(value, bytes)
+      value.to_s.encode("UTF-8", invalid: :replace, undef: :replace).byteslice(0, bytes).scrub("")
     end
 
     def serialize_detection(det)
       {
-        "queries" => det.queries,
-        "caller_strings" => det.raw_caller_strings,
+        "queries" => det.queries.first(MAX_SAMPLES).map { |sql| bounded(sql, MAX_SQL_BYTES) },
+        "caller_strings" => det.raw_caller_strings.first(MAX_FRAMES).map { |frame| bounded(frame, MAX_FRAME_BYTES) },
         "count" => det.count,
-        "adapter" => det.adapter,
+        "adapter" => det.adapter && bounded(det.adapter, 128),
         "fingerprint" => det.fingerprint,
         "issue_id" => det.issue_id,
-        "connection_id" => det.connection_id
+        "connection_id" => det.connection_id && bounded(det.connection_id, 256)
       }
     end
 
@@ -151,7 +162,8 @@ module AndOne
         count: det_data["count"],
         adapter: det_data["adapter"],
         connection_id: det_data["connection_id"],
-        issue_id: det_data["issue_id"]
+        issue_id: det_data["issue_id"],
+        fingerprint: det_data["fingerprint"]
       )
       Entry.new(
         detection: det,
@@ -163,14 +175,6 @@ module AndOne
 
     def parse_time(str)
       str ? Time.parse(str) : nil
-    end
-
-    def default_dir
-      if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
-        Rails.root.join("tmp", "and_one").to_s
-      else
-        File.join(Dir.pwd, "tmp", "and_one")
-      end
     end
   end
 end

--- a/lib/and_one/aggregate_store.rb
+++ b/lib/and_one/aggregate_store.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+
+module AndOne
+  module AggregateStore
+    # Stores implement transaction { |data| ... } and return the block result.
+    # The facade owns retention; stores own synchronization and atomic commit.
+    class Memory
+      def initialize
+        @data = {}
+        @mutex = Mutex.new
+      end
+
+      def transaction
+        @mutex.synchronize { yield @data }
+      end
+
+      def reset!
+        transaction(&:clear)
+      end
+    end
+
+    class FileStore
+      MAX_BYTES = 4 * 1024 * 1024
+
+      def initialize(path)
+        @session = path if path.respond_to?(:activate!)
+        @path = @session ? @session.path : path
+        @mutex = Mutex.new
+      end
+
+      def reset!
+        transaction(reset: true, &:clear)
+      end
+
+      def transaction(reset: false)
+        @mutex.synchronize do
+          @session&.activate!
+          FileUtils.mkdir_p(@path, mode: 0o700)
+          File.open(File.join(@path, "aggregate.lock"), File::RDWR | File::CREAT, 0o600) do |lock|
+            lock.flock(File::LOCK_EX)
+            data = reset ? {} : read_data
+            before = JSON.generate(data)
+            result = yield data
+            output = JSON.generate(data)
+            write_data(output) if reset || before != output
+            result
+          end
+        end
+      end
+
+      private
+
+      def read_data
+        path = File.join(@path, "aggregate.json")
+        return {} unless File.exist?(path)
+
+        input = File.open(path, "rb") { |file| file.read(MAX_BYTES + 1) }
+        raise IOError, "Aggregate exceeds byte limit" if input.bytesize > MAX_BYTES
+
+        data = JSON.parse(input)
+        raise IOError, "Invalid aggregate document" unless data.is_a?(Hash)
+
+        data
+      end
+
+      def write_data(output)
+        raise IOError, "Aggregate exceeds byte limit" if output.bytesize > MAX_BYTES
+
+        path = File.join(@path, "aggregate.json")
+        temporary = "#{path}.tmp"
+        begin
+          File.open(temporary, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+            written = file.write(output)
+            raise IOError, "Incomplete aggregate write" unless written == output.bytesize
+
+            file.flush
+          end
+          File.rename(temporary, path)
+        ensure
+          FileUtils.rm_f(temporary)
+        end
+      end
+    end
+  end
+end

--- a/lib/and_one/configuration.rb
+++ b/lib/and_one/configuration.rb
@@ -4,7 +4,39 @@ module AndOne
   # Service settings can change between scans. Flush the old writer before
   # replacing it; a failed flush rejects the change rather than losing entries.
   module Configuration
-    attr_reader :aggregate_path, :logfile, :logfile_format, :ignore_file_path
+    attr_reader :aggregate_path, :logfile_format, :ignore_file_path, :aggregate_store, :storage_strict
+
+    %i[aggregate_store storage_strict].each do |setting|
+      define_method("#{setting}=") do |value|
+        @singleton_mutex.synchronize do
+          @aggregate = nil unless instance_variable_get("@#{setting}") == value
+          instance_variable_set("@#{setting}", value)
+        end
+      end
+    end
+
+    def logfile
+      @logfile == :session ? File.join(session.path, "findings.log") : @logfile
+    end
+
+    def session
+      environment = current_env || "development"
+      root = defined?(Rails) && Rails.respond_to?(:root) && Rails.root ? Rails.root.to_s : Dir.pwd
+      key = [root, environment, Session.default_id(environment)]
+      @session_mutex.synchronize do
+        @session = Session.new(root: File.join(root, "tmp/and_one/sessions"), environment: environment, id: key.last) if @session_key != key
+        @session_key = key
+        @session
+      end
+    end
+
+    # Call only while session writers are quiescent; running scans may repopulate it.
+    # Explicit custom paths are owned by the caller and reset as configured.
+    def reset_session!
+      logfile_writer&.flush!
+      aggregate.reset!
+      LogfileWriter.truncate!(logfile)
+    end
 
     def aggregate_path=(value)
       @singleton_mutex.synchronize do
@@ -35,7 +67,7 @@ module AndOne
     def apply_rails_defaults
       active = Rails.env.development? || Rails.env.test?
       defaults = { enabled: active, raise_on_detect: Rails.env.test?,
-                   logfile: active ? Rails.root.join("log/and_one.log").to_s : nil,
+                   logfile: active ? :session : nil,
                    dev_toast: Rails.env.development? }
       defaults.each do |key, value|
         public_send("#{key}=", value) unless instance_variable_defined?("@#{key}")

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -10,7 +10,7 @@ module AndOne
     attr_reader :queries, :caller_locations, :count, :adapter, :connection_id
 
     def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil,
-                   connection_id: nil, issue_id: nil)
+                   connection_id: nil, issue_id: nil, fingerprint: nil)
       @queries = queries
       @caller_locations = caller_locations
       @raw_caller_strings_override = raw_caller_strings
@@ -18,6 +18,7 @@ module AndOne
       @adapter = adapter
       @connection_id = connection_id
       @issue_id = issue_id
+      @fingerprint = fingerprint
     end
 
     # Returns the SQL of the first query as the representative example

--- a/lib/and_one/logfile_writer.rb
+++ b/lib/and_one/logfile_writer.rb
@@ -9,10 +9,14 @@ module AndOne
   class LogfileWriter
     MAX_PENDING = 1000
 
-    # Clear stale findings from a previous boot.  Called once in the railtie
-    # before workers fork so every worker starts with a clean file.
+    # Explicit reset only. Booting another process must never truncate findings.
     def self.truncate!(path)
-      File.truncate(path, 0) if path && File.exist?(path)
+      return unless path && File.exist?(path)
+
+      File.open(path, File::RDWR) do |file|
+        file.flock(File::LOCK_EX)
+        file.truncate(0)
+      end
     end
 
     def initialize(path:, format: :text)
@@ -49,7 +53,7 @@ module AndOne
     private
 
     def append(output)
-      File.open(@path, File::RDWR | File::CREAT, 0o644) do |file|
+      File.open(@path, File::RDWR | File::CREAT, 0o600) do |file|
         file.flock(File::LOCK_EX)
         original_size = file.size
         begin

--- a/lib/and_one/railtie.rb
+++ b/lib/and_one/railtie.rb
@@ -8,17 +8,11 @@ module AndOne
 
     initializer "and_one.configure", after: :load_config_initializers do |app|
       if AndOne.enabled?
-        # Truncate stale findings from previous boot before workers fork
-        LogfileWriter.truncate!(AndOne.logfile)
-
         at_exit do
           AndOne.logfile_writer&.flush!
         rescue StandardError
           # Swallow errors during shutdown to avoid confusing output
         end
-
-        # Reset aggregate on server boot for a fresh session
-        AndOne.aggregate.reset!
 
         # Rack middleware for web requests
         app.middleware.insert_before(0, AndOne::Middleware)

--- a/lib/and_one/reporting.rb
+++ b/lib/and_one/reporting.rb
@@ -6,7 +6,7 @@ module AndOne
     private
 
     def report(detections)
-      new_detections = detections.select { |detection| aggregate.record(detection) }
+      new_detections = aggregate.record_many(detections)
       safely_deliver do
         writer = logfile_writer
         writer&.record(new_detections)

--- a/lib/and_one/session.rb
+++ b/lib/and_one/session.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "digest"
+require "securerandom"
+require "fileutils"
+
+module AndOne
+  # Development processes join a stable session; test boots get independent IDs.
+  # The random default is allocated before forking, so preloaded workers join it.
+  class Session
+    RUN_ID = SecureRandom.hex(16).freeze
+
+    def self.default_id(environment)
+      ENV.fetch("AND_ONE_SESSION") { environment == "test" ? RUN_ID : "default" }
+    end
+
+    def initialize(root:, environment:, id:)
+      @root = root
+      @key = Digest::SHA256.hexdigest([environment, id].join("\0"))
+      @mutex = Mutex.new
+    end
+
+    def path
+      File.join(@root, @key)
+    end
+
+    # Keep a shared lease open for this process lifetime. Cleanup cannot remove
+    # live sessions, including leases inherited by preloaded workers.
+    def activate!
+      @mutex.synchronize do
+        return path if @lease && File.directory?(path)
+
+        FileUtils.mkdir_p(@root, mode: 0o700)
+        with_registry_lock do
+          FileUtils.mkdir_p(path, mode: 0o700)
+          @lease = File.open(File.join(path, "session.lock"), File::RDWR | File::CREAT, 0o600) # rubocop:disable Style/FileOpen -- lifetime lease
+          @lease.flock(File::LOCK_SH)
+          FileUtils.touch(File.join(path, "session.lock"))
+        end
+      end
+      path
+    end
+
+    # Explicit maintenance only: inspect at most limit sessions. Call again for
+    # large directories. No boot-time history deletion or unbounded directory scan.
+    def cleanup!(older_than: 7 * 86_400, limit: 100)
+      return 0 unless File.directory?(@root)
+      raise ArgumentError, "positive cleanup limits required" unless older_than.positive? && limit.positive?
+
+      removed = 0
+      with_registry_lock do
+        cleanup_names(limit).each do |name|
+          next unless name.match?(/\A[0-9a-f]{64}\z/)
+
+          directory = File.join(@root, name)
+          next if File.symlink?(directory) || !File.directory?(directory)
+
+          removed += 1 if remove_stale(directory, Time.now - older_than)
+        end
+      end
+      removed
+    end
+
+    private
+
+    def cleanup_names(limit)
+      @cleanup_entries ||= Dir.each_child(@root)
+      names = []
+      limit.times { names << @cleanup_entries.next }
+      names
+    rescue StopIteration
+      @cleanup_entries = nil
+      names
+    end
+
+    def with_registry_lock
+      File.open(File.join(@root, "sessions.lock"), File::RDWR | File::CREAT, 0o600) do |file|
+        file.flock(File::LOCK_EX)
+        yield
+      end
+    end
+
+    def remove_stale(directory, cutoff)
+      File.open(File.join(directory, "session.lock"), File::RDWR | File::CREAT, 0o600) do |lease|
+        return false unless lease.flock(File::LOCK_EX | File::LOCK_NB)
+
+        # Directory mtime tracks aggregate renames; logfile mtime tracks appends.
+        latest = [directory, *Dir.glob(File.join(directory, "{aggregate.json,findings.log,session.lock}"))]
+                 .map { |file| File.mtime(file) }.max
+        return false unless latest < cutoff
+
+        FileUtils.rm_rf(directory)
+        true
+      end
+    end
+  end
+end

--- a/lib/and_one/session.rb
+++ b/lib/and_one/session.rb
@@ -33,7 +33,7 @@ module AndOne
         FileUtils.mkdir_p(@root, mode: 0o700)
         with_registry_lock do
           FileUtils.mkdir_p(path, mode: 0o700)
-          @lease = File.open(File.join(path, "session.lock"), File::RDWR | File::CREAT, 0o600) # rubocop:disable Style/FileOpen -- lifetime lease
+          @lease = File.new(File.join(path, "session.lock"), File::RDWR | File::CREAT, 0o600)
           @lease.flock(File::LOCK_SH)
           FileUtils.touch(File.join(path, "session.lock"))
         end

--- a/test/test_aggregate_storage.rb
+++ b/test/test_aggregate_storage.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestAggregateStorage < Minitest::Test
+  include AndOneTestHelper
+
+  def detection(index = 0, large: false)
+    AndOne::Detection.new(queries: Array.new(20) { "SELECT * FROM posts WHERE id = #{index} #{"x" * (large ? 10_000 : 0)}" },
+                          raw_caller_strings: Array.new(100) { "app/example.rb:#{index}:#{"x" * 1000}" }, count: 100)
+  end
+
+  def test_memory_is_default_and_bounded
+    aggregate = AndOne::Aggregate.new
+    (AndOne::Aggregate::MAX_ENTRIES + 5).times { |index| aggregate.record(detection(index, large: true)) }
+    assert_equal AndOne::Aggregate::MAX_ENTRIES, aggregate.size
+    refute aggregate.detections.key?(detection(0, large: true).issue_id)
+    stored = aggregate.detections.values.last.detection
+    assert_equal 100, stored.count
+    assert_equal 5, stored.queries.size
+    assert(stored.queries.all? { |sql| sql.bytesize <= AndOne::Aggregate::MAX_SQL_BYTES })
+    assert_equal 20, stored.raw_caller_strings.size
+    assert(stored.raw_caller_strings.all? { |frame| frame.bytesize <= AndOne::Aggregate::MAX_FRAME_BYTES })
+    assert_equal detection(104, large: true).fingerprint, stored.fingerprint
+  end
+
+  def test_file_retention_bounds_large_payloads_and_keeps_original_identity
+    aggregate = AndOne::Aggregate.new(path: @aggregate_tmpdir, strict: true)
+    batch = Array.new(105) { |index| detection(index, large: true) }
+    aggregate.record_many(batch)
+    stored = aggregate.detections
+    assert_equal 100, stored.size
+    refute stored.key?(batch.first.issue_id)
+    assert_equal batch.last.fingerprint, stored.fetch(batch.last.issue_id).detection.fingerprint
+    assert File.size(File.join(@aggregate_tmpdir, "aggregate.json")) <= AndOne::AggregateStore::FileStore::MAX_BYTES
+    assert_equal batch.last.count, stored.fetch(batch.last.issue_id).detection.count
+  end
+
+  def test_one_transaction_per_scan_and_round_trip
+    store = AndOne::AggregateStore::FileStore.new(@aggregate_tmpdir)
+    calls = 0
+    transaction = store.method(:transaction)
+    store.define_singleton_method(:transaction) do |&block|
+      calls += 1
+      transaction.call(&block)
+    end
+    aggregate = AndOne::Aggregate.new(store: store)
+    batch = [detection(1), detection(2)]
+    assert_equal batch, aggregate.record_many(batch)
+    assert_empty aggregate.record_many(batch)
+    assert_equal 2, calls
+    reader = AndOne::Aggregate.new(path: @aggregate_tmpdir)
+    assert_equal [2, 2], reader.detections.values.map(&:occurrences)
+    assert File.size(File.join(@aggregate_tmpdir, "aggregate.json")) <= AndOne::AggregateStore::FileStore::MAX_BYTES
+    return if Gem.win_platform?
+
+    %w[aggregate.json aggregate.lock].each do |name|
+      assert_equal 0o600, File.stat(File.join(@aggregate_tmpdir, name)).mode & 0o777
+    end
+  end
+
+  def test_independent_processes_and_preloaded_store_preserve_counts
+    skip "fork unavailable" unless Process.respond_to?(:fork)
+
+    aggregate = AndOne::Aggregate.new(path: @aggregate_tmpdir, strict: true)
+    aggregate.record(detection)
+    children = 3.times.map do
+      fork do
+        # One inherited store and one independently constructed store per child.
+        fresh = AndOne::Aggregate.new(path: @aggregate_tmpdir, strict: true)
+        5.times do
+          aggregate.record(detection)
+          fresh.record(detection)
+        end
+        exit! 0
+      end
+    end
+    children.each { |pid| assert Process.wait2(pid).last.success? }
+    assert_equal 31, aggregate.detections.values.first.occurrences
+  end
+
+  def test_malformed_and_oversized_data_is_not_silently_replaced
+    path = File.join(@aggregate_tmpdir, "aggregate.json")
+    ["{broken", "[]", '{"bad":{}}', " " * (AndOne::AggregateStore::FileStore::MAX_BYTES + 1)].each do |input|
+      File.write(path, input)
+      aggregate = AndOne::Aggregate.new(path: @aggregate_tmpdir)
+      _out, err = capture_io do
+        2.times { assert aggregate.record(detection) }
+        assert_empty aggregate.detections
+      end
+      assert_equal 1, err.lines.size
+      assert_equal input, File.read(path)
+      aggregate.reset!
+      assert_equal({}, JSON.parse(File.read(path)))
+      assert aggregate.record(detection)
+    end
+  end
+
+  def test_missing_directory_is_created_lazily_and_open_failures_are_best_effort
+    path = File.join(@aggregate_tmpdir, "nested/store")
+    aggregate = AndOne::Aggregate.new(path: path)
+    refute File.exist?(path)
+    assert aggregate.record(detection)
+    assert File.exist?(File.join(path, "aggregate.json"))
+    File.stub(:open, ->(*) { raise Errno::EACCES }) do
+      _out, err = capture_io { assert aggregate.record(detection) }
+      assert_includes err, "Errno::EACCES"
+      assert_raises(Errno::EACCES) { AndOne::Aggregate.new(path: path, strict: true).record(detection) }
+    end
+  end
+
+  def test_interrupted_replace_preserves_previous_document_and_cleans_temp
+    aggregate = AndOne::Aggregate.new(path: @aggregate_tmpdir)
+    aggregate.record(detection)
+    path = File.join(@aggregate_tmpdir, "aggregate.json")
+    before = File.read(path)
+    File.stub(:rename, ->(*) { raise IOError, "interrupted" }) do
+      capture_io { assert aggregate.record(detection(2)) }
+    end
+    assert_equal before, File.read(path)
+    refute File.exist?("#{path}.tmp")
+    assert aggregate.record(detection(2))
+    assert_equal 2, aggregate.size
+  end
+
+  def test_partial_temp_write_preserves_previous_document
+    aggregate = AndOne::Aggregate.new(path: @aggregate_tmpdir)
+    aggregate.record(detection)
+    path = File.join(@aggregate_tmpdir, "aggregate.json")
+    before = File.read(path)
+    open_file = File.method(:open)
+    failing_open = lambda do |name, *args, &block|
+      open_file.call(name, *args) do |file|
+        if name.end_with?(".tmp")
+          original_write = file.method(:write)
+          file.define_singleton_method(:write) { |output| original_write.call(output.byteslice(0, 10)) }
+        end
+        block.call(file)
+      end
+    end
+    File.stub(:open, failing_open) { capture_io { assert aggregate.record(detection(2)) } }
+    assert_equal before, File.read(path)
+    refute File.exist?("#{path}.tmp")
+  end
+
+  def test_failed_storage_does_not_suppress_enforcement_or_delivery
+    store = Object.new
+    def store.transaction
+      raise IOError, "private filesystem details"
+    end
+    AndOne.instance_variable_set(:@aggregate, AndOne::Aggregate.new(store: store))
+    received = []
+    AndOne.notifications_callback = ->(items, *) { received.concat(items) }
+    AndOne.raise_on_detect = true
+    _out, err = capture_io do
+      assert_raises(AndOne::NPlus1Error) { AndOne.send(:report, [detection]) }
+    end
+    assert_equal 1, received.size
+    assert_includes err, "storage failed"
+    refute_includes err, "private filesystem details"
+    AndOne.raise_on_detect = false
+    AndOne.send(:report, [detection])
+    assert_equal 2, received.size
+  end
+end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -9,6 +9,8 @@ class TestConfiguration < Minitest::Test
     previous = AndOne.aggregate
     AndOne.aggregate_path = File.join(@aggregate_tmpdir, "other")
     refute_same previous, AndOne.aggregate
+    refute File.exist?(AndOne.aggregate_path), "storage is lazy"
+    AndOne.aggregate.record(AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2))
     assert File.directory?(AndOne.aggregate_path)
   end
 

--- a/test/test_rails_configuration.rb
+++ b/test/test_rails_configuration.rb
@@ -56,10 +56,11 @@ class TestRailsConfiguration < Minitest::Test
       AndOne.raise_on_detect = false
     RUBY
       abort "default storage touched" if File.exist?("tmp/and_one")
-      abort "custom storage unused" unless File.directory?("custom_aggregate")
+      abort "premature storage" if File.exist?("custom_aggregate")
       abort "raise overwritten" if AndOne.raise_on_detect
       detection = AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)
       AndOne.send(:report, [detection])
+      abort "custom storage unused" unless File.directory?("custom_aggregate")
       entry = JSON.parse(File.read("custom_logs/findings.jsonl"))
       abort "wrong format" unless entry["event"] == "n_plus_one_detected"
       abort "default logfile touched" if File.exist?("log/and_one.log")

--- a/test/test_sessions.rb
+++ b/test/test_sessions.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "rbconfig"
+
+class TestSessions < Minitest::Test
+  include AndOneTestHelper
+
+  def boot(environment, id: nil)
+    source = <<~RUBY
+      require "rails/all"
+      require "and_one"
+      class SessionApp < Rails::Application
+        config.root = Dir.pwd
+        config.eager_load = false
+        config.secret_key_base = "test" * 32
+        config.logger = Logger.new(File::NULL)
+        config.active_support.deprecation = :stderr
+      end
+      AndOne.aggregate_store = :file
+      Rails.application.initialize!
+      detection = AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)
+      AndOne.aggregate.record(detection)
+      AndOne.logfile_writer.record([detection])
+      AndOne.logfile_writer.flush!
+      puts JSON.generate(path: AndOne.session.path, logfile: AndOne.logfile,
+                         occurrences: AndOne.aggregate.detections.values.first.occurrences)
+    RUBY
+    output, status = Open3.capture2e({ "RAILS_ENV" => environment, "AND_ONE_SESSION" => id },
+                                     RbConfig.ruby, "-I", File.expand_path("../lib", __dir__), "-e", source,
+                                     chdir: @aggregate_tmpdir)
+    assert status.success?, output
+    JSON.parse(output.lines.last)
+  end
+
+  def test_independent_rails_boots_join_development_without_clearing_either_sink
+    first = boot("development")
+    before = File.read(first.fetch("logfile"))
+    second = boot("development")
+    assert_equal first.fetch("path"), second.fetch("path")
+    assert_equal 2, second.fetch("occurrences")
+    assert_equal before * 2, File.read(second.fetch("logfile"))
+    assert_equal 0o600, File.stat(second.fetch("logfile")).mode & 0o777 unless Gem.win_platform?
+  end
+
+  def test_test_runs_and_environments_are_isolated_but_explicit_workers_can_join
+    first = boot("test")
+    second = boot("test")
+    refute_equal first.fetch("path"), second.fetch("path")
+    assert_equal 1, second.fetch("occurrences")
+    shared = boot("test", id: "ci-run-123")
+    assert_equal 2, boot("test", id: "ci-run-123").fetch("occurrences")
+    dev = boot("development", id: "ci-run-123")
+    refute_equal shared.fetch("path"), dev.fetch("path")
+    assert_equal 1, dev.fetch("occurrences")
+  end
+
+  def session(id)
+    AndOne::Session.new(root: File.join(@aggregate_tmpdir, "sessions"), environment: "test", id: id)
+  end
+
+  def test_preloaded_workers_inherit_identity_and_live_lease
+    skip "fork unavailable" unless Process.respond_to?(:fork)
+
+    active = session(AndOne::Session.default_id("test"))
+    path = active.activate!
+    pid = fork do
+      fresh = session(AndOne::Session.default_id("test"))
+      exit! 1 unless fresh.path == path
+      AndOne::Aggregate.new(path: fresh.activate!, strict: true).record(
+        AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)
+      )
+      exit! 0
+    end
+    assert Process.wait2(pid).last.success?
+    assert_equal 1, AndOne::Aggregate.new(path: path).size
+    age_session(path)
+    assert_equal 0, session("maintenance").cleanup!(older_than: 1)
+    assert File.directory?(path)
+  end
+
+  def age_session(path)
+    ([path] + Dir.glob(File.join(path, "*"))).each { |file| File.utime(Time.at(0), Time.at(0), file) }
+  end
+
+  def test_bounded_cleanup_removes_only_stale_unleased_sessions
+    old = session("old")
+    FileUtils.mkdir_p(old.path)
+    File.write(File.join(old.path, "session.lock"), "")
+    age_session(old.path)
+    recent = session("recent")
+    FileUtils.mkdir_p(recent.path)
+    File.write(File.join(recent.path, "session.lock"), "")
+    active = session("active")
+    active.activate!
+    age_session(active.path)
+    maintenance = session("maintenance")
+    assert_operator maintenance.cleanup!(older_than: 1, limit: 1), :<=, 1
+    maintenance.cleanup!(older_than: 1)
+    refute File.exist?(old.path)
+    assert File.exist?(recent.path)
+    assert File.exist?(active.path)
+  end
+
+  def test_reset_affects_only_configured_session
+    other = AndOne::Aggregate.new(path: session("other").activate!)
+    detection = AndOne::Detection.new(queries: ["SELECT * FROM posts"], count: 2)
+    other.record(detection)
+    AndOne.aggregate.record(detection)
+    AndOne.logfile = File.join(@aggregate_tmpdir, "findings.log")
+    AndOne.logfile_writer.record([detection])
+    AndOne.reset_session!
+    assert AndOne.aggregate.empty?
+    assert_equal "", File.read(AndOne.logfile)
+    assert_equal 1, other.size
+  end
+end


### PR DESCRIPTION
## Summary

Closes #8.
Closes #9.

These are the two directly dependent lifecycle/storage issues; this PR handles their shared persistence boundary without expanding into SQL redaction, classification, or query-cost ranking.

- Remove destructive aggregate resets and logfile truncation at Rails boot.
- Add environment/session-scoped default paths, stable development sessions, independent test-run identities, and explicit `AND_ONE_SESSION` sharing for cooperating workers.
- Add explicit reset and bounded, lease-aware stale-session cleanup.
- Default aggregates to bounded process-local memory; opt into shared local files via `aggregate_store = :file` or an exact custom `aggregate_path`.
- Preserve the public aggregate API, batch all findings in a scan into one transaction, retain 100 least-recently-observed issues, cap SQL/backtrace samples, and enforce a 4 MiB JSON document limit.
- Keep counts consistent under independent/forked writers. Preserve corrupt documents and previous data on failed writes; default failures emit rate-limited diagnostics without failing application work or suppressing N+1 enforcement. Add opt-in strict mode.
- Use restrictive permissions for new storage/log files; preserve original identities when persisted samples are truncated.

## Compatibility / limits

This intentionally changes defaults: aggregate storage is memory-backed unless explicitly enabled, and Rails dev/test logfiles move to the session directory. Exact custom paths retain caller-owned lifecycle/isolation. Old default files are left untouched. See `docs/storage.md` for migration, reset ownership, failure semantics, retention, and cleanup.

SQL remains raw (#10 is not addressed). Logfiles still need rotation/reset within long-lived active sessions. Local file locking/atomic rename is not multi-host storage or power-loss durability. Strict storage mode deliberately propagates errors.

## Verification

- `bundle exec rake`: **302 runs, 1,570 assertions, zero failures/errors/skips**; **85 files inspected, no RuboCop offenses**.
- New regressions cover independent Rails boots, test/environment isolation, explicit sharing, preloaded workers, session leases/cleanup, scoped reset, process-safe counts, transaction counts, retention/sample/document bounds, restrictive permissions, malformed/oversized data recovery, missing directories, permission failures, interrupted replacements/partial temporary writes, and enforcement/delivery on storage failure.
- `bundle exec ruby bench/aggregate_storage.rb`: reproducible growth benchmark with results recorded in `docs/storage.md`. Retained entries plateau at 100; representative file size is ~35 KB at both 100 and 1,000 historical findings. No wall-clock CI assertions.
