### PR TITLE
Measure query costs and rank findings by observed impact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Measure eligible SQL notification costs with monotonic timing, persist constant-space per-issue rollups, expose JSON summaries, and sort the dashboard by observed time, occurrences, or executed queries; label cache exclusions and unknown historical coverage (#22).
+
 ### Fixed
 
 - Preserve shared aggregate/log findings across boots, isolate environment/test sessions, and provide explicit reset and bounded stale-session cleanup (#8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Exclude mysql2 0.5.7 from the compatibility test stack due to its upstream empty-prepared-result crash; retain prepared-query coverage and document the application dependency workaround.
 - Preserve shared aggregate/log findings across boots, isolate environment/test sessions, and provide explicit reset and bounded stale-session cleanup (#8).
 - Default to bounded in-memory aggregates, opt into shared file storage, batch each scan into one transaction, and diagnose persistence failures without disrupting application work or N+1 enforcement (#9).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AndOne stays completely invisible until it detects an N+1 query — then it poin
 - **Bounded deduplication** — occurrence counts with in-memory storage by default and opt-in shared, session-scoped file storage
 - **Test matchers** — Minitest (`assert_no_n_plus_one`) and RSpec (`expect { }.not_to cause_n_plus_one`)
 - **Dev toast notifications** — in-page toast on every page that triggers an N+1, with a link to the dashboard
-- **Dev UI dashboard** — browse `/__and_one` in development for a live N+1 overview
+- **Dev UI dashboard** — browse `/__and_one` in development; rank findings by observed SQL time, occurrences, or executed query count
 - **Rails console integration** — auto-scans in `rails console` and prints warnings inline
 - **Structured JSON logging** — JSON output mode for Datadog, Splunk, and other log aggregation services
 - **Per-environment thresholds** — different `min_n_queries` for development vs test
@@ -79,7 +79,9 @@ Scans capture synchronous ActiveRecord SQL in the **current fiber**. Child fiber
 
 One process-level subscriber routes events to the active context. Each repeated shape/location retains its first five SQL samples plus an exact total count: `Detection#queries` is a sample, while `Detection#count` includes all eligible occurrences. Query-ignore rules still inspect every occurrence. Unique groups and individual SQL sizes are not capped.
 
-See [capture boundaries, retention, and benchmark commands](docs/capture.md) for details.
+Findings expose `query_cost` timing summaries from monotonic SQL notifications; aggregate entries roll them up across repeated occurrences. Cache hits and async work are excluded, and historical missing costs remain unknown. These are observed costs, not estimated savings. JSON rollups are available through `AndOne::JsonFormatter.new.format_aggregate(AndOne.aggregate.detections)`.
+
+See [capture boundaries, measured costs, retention, and benchmark commands](docs/capture.md) for details.
 
 ## What You'll See
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -67,6 +67,51 @@ are evaluated during capture against the ignore-list instance selected at scan
 start. Reload ignore files between scans, not during a scan. Other ignore rules
 and thresholds continue to apply normally.
 
+## Observed finding costs
+
+SQL notification start/finish timestamps use ActiveSupport's monotonic subscriber.
+Each finding's `query_cost` records `query_count`, `timed_query_count`,
+`total_duration_ms`, `min_duration_ms`, `max_duration_ms`, and `occurrences` (one
+for a scan-local finding). `query_cost.to_h` also includes `mean_duration_ms`
+(the mean over timed queries) and `cached_queries: "excluded"`.
+
+These metrics cover **only the eligible executed reads in that finding**, not
+all SQL in the request/job. Existing thresholds, ignores, pause/fiber boundaries,
+and async/schema/cache exclusions are unchanged. Cache hits do not contribute
+to counts or time. Timing is the observed SQL notification interval, including
+adapter overhead, not database-server CPU time, request wall time, or estimated
+avoidable work. No savings estimate is produced.
+
+Direct `Detector#record` calls without `duration_ms:` still count queries, but
+have no timing. Negative, nonfinite, and missing durations are not measured;
+zero is a valid measurement. Check `timed_query_count` before interpreting a
+zero total; mean/min/max are null when nothing was timed. Partial timing totals
+sum only known intervals, never extrapolate to missing queries.
+
+`Detection#query_cost` and JSON `query_cost` describe a single finding occurrence.
+`AndOne.aggregate.detections` entries expose cumulative `query_cost` across all
+retained occurrences, even when repeated findings are deduplicated from logs.
+Query count, time total, and extrema merge in constant space; no individual
+query timings or bind values are retained. Historical entries without metrics
+remain unknown. After a new observation, the cost's `occurrences` reports its
+coverage relative to the entry's total occurrences; historical counts/times
+are never invented. Retention/eviction/reset also resets the cost history.
+
+To export rollups (always a JSON array):
+
+```ruby
+AndOne::JsonFormatter.new.format_aggregate(AndOne.aggregate.detections)
+# Each entry includes occurrences, first_seen_at, last_seen_at,
+# cumulative_query_cost, and the original finding's query_cost.
+```
+
+The dashboard defaults to descending cumulative observed time. Links select
+`?sort=time`, `?sort=occurrences`, or `?sort=queries`; unknown historical metrics
+sort last and ties use issue ID. Rows label executed/timed query counts and
+occurrence coverage. Totals are not comparable as complete costs when coverage
+is partial. Memory/storage add only a fixed-size summary per group/issue, not
+an event history; the existing distinct-group memory caveat still applies.
+
 ## Reproducible benchmark
 
 ```sh

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -20,6 +20,22 @@ runtime dependencies of AndOne. Use upstream-compatible dependency versions in
 applications too. The earlier ModuleLength offense has already been resolved by
 existing configuration/reporting extractions; the matrix runs lint without disabling it.
 
+### MySQL driver limitation
+
+The test Gemfile excludes **mysql2 0.5.7**, which can segfault when Rails reads
+field metadata from an empty prepared-query result. This reproduces with plain
+ActiveRecord and no AndOne loaded; batching can trigger it when fetching past the
+last row. See [mysql2 #1426](https://github.com/brianmario/mysql2/issues/1426) and
+[the merged fix #1427](https://github.com/brianmario/mysql2/pull/1427). At the time
+of verification the fix is not released; the matrix resolves mysql2 0.5.6.
+Prepared statements and empty-result/batching checks remain enabled.
+
+Applications using the affected release should choose a verified driver version,
+for example `gem "mysql2", "~> 0.5", "!= 0.5.7"`, and run their own tests. AndOne
+does not monkey-patch the native driver, disable prepared statements, or enforce
+this optional dependency at runtime. Revisit the exclusion when a fixed release
+is available and passes the empty-result regression.
+
 The fast default remains `bundle exec rake`. To reproduce a matrix job, select its
 Ruby first (for example `mise use ruby@3.2`, or your preferred version manager):
 
@@ -75,7 +91,8 @@ there is deliberately no aggregate accuracy/marketing score.
 
 A separate integration check asserts prepared statements are enabled, observes real
 adapter bind metadata on repeated association queries, and checks preload removes
-the finding. Schema creation, fixture writes, and model metadata warmup are outside
+the finding. An additional regression checks empty bound results remain readable
+and their executed queries are measured. Schema creation, fixture writes, and model metadata warmup are outside
 both scan and measurement. Each measurement begins uncached; only the cache scenario
 explicitly enables caching within that scope. Counts exclude cache hits, schema
 notifications, and transaction control. No timing assertions or arbitrary workload

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -79,7 +79,12 @@ the retained history, not lifetime totals. Each retained first occurrence holds:
 
 - at most 5 SQL samples, each at most 2,048 UTF-8 bytes;
 - at most 20 backtrace frames, each at most 256 UTF-8 bytes;
-- bounded adapter/connection labels, original count, and stable identities.
+- bounded adapter/connection labels, original count, and stable identities;
+- constant-space query cost summaries for the first occurrence and all retained
+  occurrences (count, timed count, total/min/max milliseconds, coverage).
+
+[Cost metrics](capture.md#observed-finding-costs) survive persistence reloads;
+missing historical metrics remain unknown and are not extrapolated.
 
 Truncation does not recompute the original fingerprint or issue ID. Detection
 thresholds, scan results, and ignores operate on the original capture, before

--- a/gemfiles/compatibility.gemfile
+++ b/gemfiles/compatibility.gemfile
@@ -8,7 +8,9 @@ gem "irb"
 # Rails 7's JSON encoder passes quirks_mode, removed in JSON 3.
 gem "json", "< 3" if ENV.fetch("RAILS_VERSION", "8.1.0").start_with?("7.")
 gem "minitest", "~> 5.16"
-gem "mysql2", "~> 0.5" if ENV["DB"] == "mysql2"
+# 0.5.7 segfaults on empty prepared results (upstream mysql2#1426/#1427).
+# Keep prepared-query coverage enabled; remove the exclusion once a fixed release is verified.
+gem "mysql2", "~> 0.5", "!= 0.5.7" if ENV["DB"] == "mysql2"
 gem "pg", "~> 1.5" if ENV["DB"] == "postgresql"
 gem "rails", "~> #{ENV.fetch("RAILS_VERSION", "8.1.0")}"
 gem "rake", "~> 13.0"

--- a/lib/and_one/aggregate.rb
+++ b/lib/and_one/aggregate.rb
@@ -19,7 +19,7 @@ module AndOne
   #   AndOne.aggregate.reset!
   #
   class Aggregate
-    Entry = Struct.new(:detection, :occurrences, :first_seen_at, :last_seen_at)
+    Entry = Struct.new(:detection, :occurrences, :first_seen_at, :last_seen_at, :query_cost)
 
     MAX_ENTRIES = 100
     MAX_SAMPLES = 5
@@ -101,10 +101,11 @@ module AndOne
       existing = data.delete(key)
       now = Time.now.iso8601
       data[key] = if existing
-                    existing.merge("occurrences" => existing.fetch("occurrences") + 1, "last_seen_at" => now)
+                    existing.merge("occurrences" => existing.fetch("occurrences") + 1, "last_seen_at" => now,
+                                   "query_cost" => merged_cost(existing, detection)&.to_h)
                   else
                     { "detection" => serialize_detection(detection), "occurrences" => 1,
-                      "first_seen_at" => now, "last_seen_at" => now }
+                      "first_seen_at" => now, "last_seen_at" => now, "query_cost" => detection.query_cost&.to_h }
                   end
       data.shift while data.size > MAX_ENTRIES
       !existing
@@ -117,10 +118,20 @@ module AndOne
 
         bounded_entry = { "detection" => serialize_detection(detection), "occurrences" => entry["occurrences"],
                           "first_seen_at" => parse_time(entry["first_seen_at"])&.iso8601,
-                          "last_seen_at" => parse_time(entry["last_seen_at"])&.iso8601 }
+                          "last_seen_at" => parse_time(entry["last_seen_at"])&.iso8601,
+                          "query_cost" => stored_cost(entry)&.to_h }
         [detection.issue_id, bounded_entry]
       end
       data.replace(normalized)
+    end
+
+    def stored_cost(entry)
+      QueryCost.new(entry["query_cost"]) if entry["query_cost"]
+    end
+
+    def merged_cost(entry, detection)
+      previous = stored_cost(entry)
+      previous ? previous.merge(detection.query_cost) : detection.query_cost
     end
 
     def safely(default:)
@@ -147,6 +158,7 @@ module AndOne
         "queries" => det.queries.first(MAX_SAMPLES).map { |sql| bounded(sql, MAX_SQL_BYTES) },
         "caller_strings" => det.raw_caller_strings.first(MAX_FRAMES).map { |frame| bounded(frame, MAX_FRAME_BYTES) },
         "count" => det.count,
+        "query_cost" => det.query_cost&.to_h,
         "adapter" => det.adapter && bounded(det.adapter, 128),
         "fingerprint" => det.fingerprint,
         "issue_id" => det.issue_id,
@@ -163,13 +175,15 @@ module AndOne
         adapter: det_data["adapter"],
         connection_id: det_data["connection_id"],
         issue_id: det_data["issue_id"],
-        fingerprint: det_data["fingerprint"]
+        fingerprint: det_data["fingerprint"],
+        query_cost: stored_cost(det_data)
       )
       Entry.new(
         detection: det,
         occurrences: entry_data["occurrences"],
         first_seen_at: parse_time(entry_data["first_seen_at"]),
-        last_seen_at: parse_time(entry_data["last_seen_at"])
+        last_seen_at: parse_time(entry_data["last_seen_at"]),
+        query_cost: stored_cost(entry_data)
       )
     end
 

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -11,8 +11,7 @@ module AndOne
     attr_reader :queries, :caller_locations, :count, :adapter, :connection_id, :query_cost
 
     # Keep the legacy keyword construction API while adding optional measurements.
-    # rubocop:disable Metrics/ParameterLists
-    def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil,
+    def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil, # rubocop:disable Metrics/ParameterLists
                    connection_id: nil, issue_id: nil, fingerprint: nil, query_cost: nil)
       @query_cost = query_cost
       @queries = queries
@@ -24,7 +23,6 @@ module AndOne
       @issue_id = issue_id
       @fingerprint = fingerprint
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Returns the SQL of the first query as the representative example
     def sample_query

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -2,15 +2,19 @@
 
 require "digest"
 require "json"
+require_relative "query_cost"
 
 module AndOne
   # Represents a single N+1 detection: the repeated queries, their call site, and metadata.
   class Detection
     # queries contains representative samples; count is the exact occurrence total.
-    attr_reader :queries, :caller_locations, :count, :adapter, :connection_id
+    attr_reader :queries, :caller_locations, :count, :adapter, :connection_id, :query_cost
 
+    # Keep the legacy keyword construction API while adding optional measurements.
+    # rubocop:disable Metrics/ParameterLists
     def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil,
-                   connection_id: nil, issue_id: nil, fingerprint: nil)
+                   connection_id: nil, issue_id: nil, fingerprint: nil, query_cost: nil)
+      @query_cost = query_cost
       @queries = queries
       @caller_locations = caller_locations
       @raw_caller_strings_override = raw_caller_strings
@@ -20,6 +24,7 @@ module AndOne
       @issue_id = issue_id
       @fingerprint = fingerprint
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Returns the SQL of the first query as the representative example
     def sample_query

--- a/lib/and_one/detector.rb
+++ b/lib/and_one/detector.rb
@@ -12,7 +12,7 @@ module AndOne
       %r{active_record/validations/uniqueness}
     ].freeze
     SAMPLE_LIMIT = 5
-    Group = Struct.new(:total, :queries, :callers, :metadata, :ignored)
+    Group = Struct.new(:total, :queries, :callers, :metadata, :ignored, :query_cost)
 
     attr_reader :detections
 
@@ -30,7 +30,9 @@ module AndOne
       @detections
     end
 
-    def record(payload)
+    def record(payload = nil, duration_ms: nil, **attributes)
+      # Preserve direct record(sql: ...) callers as well as notification hashes.
+      payload ||= attributes
       sql = payload[:sql]
       return if payload[:name] == "SCHEMA" || payload[:cached] || payload[:async]
       return if @ignore_queries.any? { |pattern| pattern.match?(sql) }
@@ -38,7 +40,7 @@ module AndOne
       metadata = ConnectionContext.metadata(payload)
       return unless ReadStatement.eligible?(sql, adapter: metadata[:connection_adapter])
 
-      record_query(sql, metadata)
+      record_query(sql, metadata, duration_ms)
     end
 
     private
@@ -52,17 +54,19 @@ module AndOne
           caller_locations: group.callers,
           count: group.total,
           adapter: group.metadata[:connection_adapter],
-          connection_id: group.metadata[:connection_id]
+          connection_id: group.metadata[:connection_id],
+          query_cost: group.query_cost
         )
       end
     end
 
-    def record_query(sql, metadata)
+    def record_query(sql, metadata, duration_ms)
       locations = caller_locations
       key = [location_fingerprint(locations), metadata[:connection_id],
              Fingerprint.generate(sql, adapter: metadata[:connection_adapter])]
       group = @groups[key] ||= new_group(locations, metadata)
       group.total += 1
+      group.query_cost.record(duration_ms)
       # Query ignore rules historically inspect ALL occurrences. Evaluate before
       # dropping samples so a late literal match still suppresses the whole group.
       group.ignored ||= @ignore_list&.query_ignored?(sql)
@@ -71,7 +75,7 @@ module AndOne
 
     def new_group(locations, metadata)
       ignored = locations.any? { |frame| @allow_stack_paths.any? { |pattern| frame.to_s.match?(pattern) } }
-      Group.new(total: 0, queries: [], callers: locations, metadata: metadata, ignored: ignored)
+      Group.new(total: 0, queries: [], callers: locations, metadata: metadata, ignored: ignored, query_cost: QueryCost.new)
     end
 
     def location_fingerprint(locations)

--- a/lib/and_one/dev_ui.rb
+++ b/lib/and_one/dev_ui.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module AndOne
   # A tiny Rack endpoint that shows all N+1s detected in the current server
   # session. Mount at `/__and_one` in development to get a mini dashboard
@@ -26,18 +28,41 @@ module AndOne
 
     private
 
-    def serve_dashboard(_env)
-      entries = AndOne.aggregate.detections
+    def serve_dashboard(env)
+      entries = sorted_entries(AndOne.aggregate.detections, env["QUERY_STRING"])
 
       html = render_html(entries)
       [200, { "content-type" => "text/html; charset=utf-8" }, [html]]
+    end
+
+    def sorted_entries(entries, query)
+      sort = URI.decode_www_form(query.to_s).to_h["sort"]
+      sort = "time" unless %w[time occurrences queries].include?(sort)
+      entries.sort_by do |key, entry|
+        cost = entry.query_cost
+        value = case sort
+                when "occurrences" then entry.occurrences
+                when "queries" then cost&.query_count
+                else cost.total_duration_ms if cost&.timed_query_count&.positive?
+                end
+        [value.nil? ? 1 : 0, -(value || 0), key]
+      end.to_h
+    end
+
+    def cost_cell(entry)
+      cost = entry.query_cost
+      return "Unknown (historical)" unless cost
+
+      time = cost.timed_query_count.positive? ? "#{format("%.3f", cost.total_duration_ms)} ms observed" : "Time unknown"
+      [time, "#{cost.query_count} executed queries; #{cost.timed_query_count} timed",
+       "Coverage: #{cost.occurrences}/#{entry.occurrences} occurrences"].map { |text| h(text) }.join("<br>")
     end
 
     def render_html(entries)
       rows = if entries.empty?
                <<~HTML
                  <tr>
-                   <td colspan="6" class="empty">
+                   <td colspan="7" class="empty">
                      No N+1 queries detected yet.
                    </td>
                  </tr>
@@ -62,6 +87,7 @@ module AndOne
                      <td>#{i + 1}</td>
                      <td><code>#{h(det.table_name || "unknown")}</code></td>
                      <td>#{entry.occurrences}</td>
+                     <td>#{cost_cell(entry)}</td>
                      <td><code class="sql">#{h(truncate(det.sample_query, 200))}</code></td>
                      <td>
                        <div class="origin">#{h(origin)}</div>
@@ -115,13 +141,18 @@ module AndOne
           <p class="subtitle">#{entries.size} unique N+1 issue#{"s" if entries.size != 1} detected this session</p>
           <div class="actions">
             <a href="#{MOUNT_PATH}">↻ Refresh</a>
+            <a href="#{MOUNT_PATH}?sort=time">Sort by observed time</a>
+            <a href="#{MOUNT_PATH}?sort=occurrences">Sort by occurrences</a>
+            <a href="#{MOUNT_PATH}?sort=queries">Sort by executed queries</a>
           </div>
+          <p class="subtitle">SQL notification time, not estimated savings. Cache hits and async queries excluded. Unknown historical costs sort last.</p>
           <table>
             <thead>
               <tr>
                 <th>#</th>
                 <th>Table</th>
-                <th>Count</th>
+                <th>Occurrences</th>
+                <th>Observed SQL cost</th>
                 <th>Query</th>
                 <th>Location</th>
                 <th>Suggested investigation</th>

--- a/lib/and_one/json_formatter.rb
+++ b/lib/and_one/json_formatter.rb
@@ -37,6 +37,18 @@ module AndOne
       detections.map { |d| format_detection(d) }
     end
 
+    # Session rollups, including repeats that are deduplicated from log output.
+    def format_aggregate(entries)
+      JSON.generate(entries.values.map do |entry|
+        format_detection(entry.detection).merge(
+          occurrences: entry.occurrences,
+          first_seen_at: entry.first_seen_at&.iso8601,
+          last_seen_at: entry.last_seen_at&.iso8601,
+          cumulative_query_cost: entry.query_cost&.to_h
+        )
+      end)
+    end
+
     private
 
     def format_detection(detection)
@@ -52,6 +64,7 @@ module AndOne
         connection_id: detection.connection_id,
         adapter: detection.adapter,
         query_count: detection.count,
+        query_cost: detection.query_cost&.to_h,
         sample_query: detection.sample_query,
         origin: format_frame(detection.origin_frame),
         fix_location: format_frame(detection.fix_location),

--- a/lib/and_one/query_cost.rb
+++ b/lib/and_one/query_cost.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AndOne
+  # Constant-space observed SQL notification costs; never an estimate of savings.
+  class QueryCost
+    FIELDS = %w[query_count timed_query_count total_duration_ms min_duration_ms max_duration_ms occurrences].freeze
+
+    attr_reader(*FIELDS)
+
+    def initialize(data = {})
+      @query_count = data.fetch("query_count", 0)
+      @timed_query_count = data.fetch("timed_query_count", 0)
+      @total_duration_ms = data.fetch("total_duration_ms", 0.0)
+      @min_duration_ms = data["min_duration_ms"]
+      @max_duration_ms = data["max_duration_ms"]
+      @occurrences = data.fetch("occurrences", 1)
+    end
+
+    def record(duration_ms)
+      @query_count += 1
+      return unless duration_ms.is_a?(Numeric) && duration_ms.finite? && duration_ms >= 0
+
+      @timed_query_count += 1
+      @total_duration_ms += duration_ms
+      @min_duration_ms = [min_duration_ms, duration_ms].compact.min
+      @max_duration_ms = [max_duration_ms, duration_ms].compact.max
+    end
+
+    def merge(other)
+      return self unless other
+
+      self.class.new(
+        "query_count" => query_count + other.query_count,
+        "timed_query_count" => timed_query_count + other.timed_query_count,
+        "total_duration_ms" => total_duration_ms + other.total_duration_ms,
+        "min_duration_ms" => [min_duration_ms, other.min_duration_ms].compact.min,
+        "max_duration_ms" => [max_duration_ms, other.max_duration_ms].compact.max,
+        "occurrences" => occurrences + other.occurrences
+      )
+    end
+
+    def to_h
+      FIELDS.to_h { |field| [field, public_send(field)] }.merge(
+        "mean_duration_ms" => timed_query_count.positive? ? total_duration_ms / timed_query_count : nil,
+        "cached_queries" => "excluded"
+      )
+    end
+  end
+end

--- a/lib/and_one/sql_subscriber.rb
+++ b/lib/and_one/sql_subscriber.rb
@@ -9,10 +9,10 @@ module AndOne
       @mutex.synchronize do
         return @subscriber if @subscriber
 
-        @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        @subscriber = ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |_, started, finished, _, payload|
           ExecutionContext[:and_one_query_captures]&.each { |capture| capture.record(payload) }
           detector = ExecutionContext.active_detector
-          detector&.record(payload)
+          detector&.record(payload, duration_ms: (finished - started) * 1000.0)
         end
       end
     end

--- a/test/test_accuracy_corpus.rb
+++ b/test/test_accuracy_corpus.rb
@@ -63,6 +63,31 @@ class TestAccuracyCorpus < Minitest::Test
     assert_empty(AndOne.scan { AccuracyCorpus.records(CorpusOwner.preload(:items), :items) })
   end
 
+  def test_empty_prepared_results_remain_readable_and_are_measured
+    connection = ActiveRecord::Base.connection
+    assert connection.prepared_statements, "#{connection.adapter_name} must exercise prepared queries"
+    # mysql2 0.5.7 frees empty prepared-result metadata before Rails reads fields.
+    # Do not skip empty results or disable prepared statements to hide that crash.
+    events = []
+    subscriber = ->(*args) { events << args.last unless args.last[:name] == "SCHEMA" }
+    results = []
+    detections = nil
+    ActiveRecord::Base.uncached do
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+        detections = AndOne.scan do
+          3.times { results << CorpusItem.where(owner_code: "missing-owner").pluck(:id) }
+        end
+      end
+    end
+
+    assert_equal [[], [], []], results
+    assert_equal 3, events.size
+    assert events.all? { |payload| !payload[:binds].empty? }, "expected bound empty-result queries"
+    assert_equal 1, detections.size
+    assert_equal 3, detections.first.count
+    assert_equal 3, detections.first.query_cost.timed_query_count
+  end
+
   private
 
   def verify_recommendation(scenario, suggestions, baseline, before, diagnostic)

--- a/test/test_query_cost.rb
+++ b/test/test_query_cost.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestQueryCost < Minitest::Test
+  include AndOneTestHelper
+
+  SQL = "SELECT * FROM posts WHERE id = 1"
+
+  def test_monotonic_notification_timings_and_cache_policy
+    AndOne.notifications_callback = ->(*) {}
+    payloads = [
+      { sql: SQL }, { sql: SQL },
+      { sql: SQL, cached: true }, { sql: SQL, async: true },
+      { sql: SQL, name: "SCHEMA" }, { sql: "UPDATE posts SET title = 'x'" }
+    ]
+    detections = AndOne.scan do
+      payloads.each_with_index do |payload, index|
+        ActiveSupport::Notifications.publish("sql.active_record", 10.0, 10.0 + ((index + 1) / 8.0), "test", payload)
+      end
+    end
+
+    assert_equal 1, detections.size
+    cost = detections.first.query_cost
+    assert_equal 2, detections.first.count
+    assert_equal 2, cost.query_count
+    assert_equal 2, cost.timed_query_count
+    assert_equal 375.0, cost.total_duration_ms
+    assert_equal 125.0, cost.min_duration_ms
+    assert_equal 250.0, cost.max_duration_ms
+    assert_equal 187.5, cost.to_h["mean_duration_ms"]
+    assert_equal "excluded", cost.to_h["cached_queries"]
+    assert_equal cost.to_h, JSON.parse(AndOne::JsonFormatter.new.format(detections))["query_cost"]
+  end
+
+  def test_instrumented_events_have_real_monotonic_measurements
+    AndOne.notifications_callback = ->(*) {}
+    detections = AndOne.scan do
+      2.times { ActiveSupport::Notifications.instrument("sql.active_record", sql: SQL) { SQL.size } }
+    end
+    cost = detections.first.query_cost
+    assert_equal 2, cost.timed_query_count
+    assert_operator cost.total_duration_ms, :>=, 0
+    assert_operator cost.max_duration_ms, :>=, cost.min_duration_ms
+  end
+
+  def test_missing_invalid_and_zero_timings
+    cost = AndOne::QueryCost.new
+    [nil, -1, Float::NAN, Float::INFINITY, "secret", 0.0, 2.0].each { |duration| cost.record(duration) }
+
+    assert_equal 7, cost.query_count
+    assert_equal 2, cost.timed_query_count
+    assert_equal 2.0, cost.total_duration_ms
+    assert_equal 0.0, cost.min_duration_ms
+    assert_equal 1.0, cost.to_h["mean_duration_ms"]
+    refute_includes JSON.generate(cost.to_h), "secret"
+  end
+
+  def test_unmeasured_direct_recording_is_not_zero_cost
+    detector = AndOne::Detector.new
+    2.times { detector.record(sql: SQL) }
+    cost = detector.finish.first.query_cost
+
+    assert_equal 2, cost.query_count
+    assert_equal 0, cost.timed_query_count
+    assert_nil cost.to_h["mean_duration_ms"]
+    assert_nil cost.min_duration_ms
+  end
+
+  def test_cost_retention_is_constant_and_ignores_and_thresholds_are_unchanged
+    detector = AndOne::Detector.new(min_n_queries: 3, ignore_queries: [/ignored/])
+    100.times do
+      detector.record({ sql: SQL }, duration_ms: 1.0)
+      detector.record({ sql: "SELECT * FROM ignored" }, duration_ms: 10.0)
+    end
+    detection = detector.finish.fetch(0)
+    assert_equal 1, detector.detections.size
+    assert_equal 100, detection.count
+    assert_equal 100.0, detection.query_cost.total_duration_ms
+    assert_equal 5, detection.queries.size
+    assert_equal 8, detection.query_cost.to_h.size
+
+    below = AndOne::Detector.new(min_n_queries: 3)
+    2.times { below.record({ sql: SQL }, duration_ms: 10.0) }
+    assert_empty below.finish
+  end
+
+  def test_repeated_occurrences_round_trip_in_both_stores
+    [AndOne::Aggregate.new, AndOne::Aggregate.new(path: @aggregate_tmpdir, strict: true)].each do |aggregate|
+      assert aggregate.record(detection("same", [1.0, 3.0]))
+      refute aggregate.record(detection("same", [6.0, 10.0, nil]))
+      entry = aggregate.detections.fetch("same")
+      assert_equal 2, entry.occurrences
+      assert_equal 2, entry.query_cost.occurrences
+      assert_equal 5, entry.query_cost.query_count
+      assert_equal 4, entry.query_cost.timed_query_count
+      assert_equal 20.0, entry.query_cost.total_duration_ms
+      assert_equal 1.0, entry.query_cost.min_duration_ms
+      assert_equal 10.0, entry.query_cost.max_duration_ms
+      assert_equal 5.0, entry.query_cost.to_h["mean_duration_ms"]
+      assert_equal 4.0, entry.detection.query_cost.total_duration_ms
+      json = JSON.parse(AndOne::JsonFormatter.new.format_aggregate(aggregate.detections)).first
+      assert_equal 2, json["occurrences"]
+      assert_equal entry.query_cost.to_h, json["cumulative_query_cost"]
+    end
+    reopened = AndOne::Aggregate.new(path: @aggregate_tmpdir, strict: true)
+    assert_equal 20.0, reopened.detections.fetch("same").query_cost.total_duration_ms
+  end
+
+  def test_historical_entries_remain_unknown_and_new_coverage_is_explicit
+    store = AndOne::AggregateStore::Memory.new
+    aggregate = AndOne::Aggregate.new(store: store)
+    aggregate.record(detection("old", nil))
+    # Model documents written before either cost field existed.
+    store.transaction do |data|
+      data.fetch("old").delete("query_cost")
+      data.fetch("old").fetch("detection").delete("query_cost")
+    end
+    assert_nil aggregate.detections.fetch("old").query_cost
+    aggregate.record(detection("old", [4.0, 6.0]))
+    entry = aggregate.detections.fetch("old")
+    assert_equal 2, entry.occurrences
+    assert_equal 1, entry.query_cost.occurrences
+    assert_equal 2, entry.query_cost.query_count
+    assert_equal 10.0, entry.query_cost.total_duration_ms
+  end
+
+  def test_dashboard_sorts_each_metric_and_places_unknown_costs_last
+    AndOne.aggregate.record(detection("historical", nil))
+    AndOne.aggregate.record(detection("expensive", [100.0, 200.0]))
+    AndOne.aggregate.record(detection("many", [1.0] * 10))
+    3.times { AndOne.aggregate.record(detection("frequent", [1.0, 1.0])) }
+
+    ui = AndOne::DevUI.new(->(_) { flunk "unexpected passthrough" })
+    { "time" => %w[expensive many frequent historical],
+      "queries" => %w[many frequent expensive historical],
+      "occurrences" => %w[frequent expensive historical many],
+      "invalid" => %w[expensive many frequent historical] }.each do |sort, expected|
+      html = ui.call("PATH_INFO" => "/__and_one", "QUERY_STRING" => "sort=#{sort}")[2].first
+      assert_equal expected, html.scan(/issue_id: (\w+)/).flatten
+      assert_includes html, "300.000 ms observed"
+      assert_includes html, "Unknown (historical)"
+      assert_includes html, "not estimated savings"
+      assert_includes html, "Cache hits and async queries excluded"
+    end
+  end
+
+  private
+
+  def detection(issue_id, durations)
+    cost = AndOne::QueryCost.new if durations
+    durations&.each { |duration| cost.record(duration) }
+    AndOne::Detection.new(queries: [SQL], count: durations&.size || 2, issue_id: issue_id, query_cost: cost)
+  end
+end


### PR DESCRIPTION
## Summary
Closes #22.

- Use monotonic SQL notifications to collect constant-space query counts, timed counts, total/min/max/mean duration per finding.
- Roll up repeated occurrences in memory and shared file storage, preserving original scan metrics and explicitly tracking historical coverage.
- Expose scan metrics in JSON and add `JsonFormatter#format_aggregate` for cumulative summaries.
- Sort the dashboard by observed cumulative time (default), occurrences, or executed query count; keep unknown historical costs last.
- Document that measurements exclude cached/async/schema/ignored work and are not estimates of savings. Detection eligibility and thresholds are unchanged.

## Validation
- `bundle exec rake`: 310 tests, 1,669 assertions; zero failures/errors/skips.
- RuboCop: 87 files, zero offenses.
- `git diff --check`: clean.
- Regression tests cover deterministic notification intervals, real instrumented events, cache/async exclusions, missing/invalid/zero timing, bounded summaries, unchanged thresholds/ignores, both stores and file reloads, historical missing fields, JSON rollups, and all dashboard sort modes.
- Locally verified with Ruby 4.0.6 / Rails 8.1.2 / SQLite; compatibility matrix remains for CI.

## Scope
Only three issues remain open. #21 depends on the broader security work in #10, and the issues request focused PRs, so this change deliberately addresses the independent measured-impact issue rather than combining unrelated work.