### PR TITLE
Redact captured SQL and guard dashboard access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Redact and bound SQL/backtrace samples before retention across all output sinks, preserve pre-redaction ignore matching, and restrict the dashboard to loopback by default with a configurable access guard. Add explicit risk-documented raw capture (#10).
 - Exclude mysql2 0.5.7 from the compatibility test stack due to its upstream empty-prepared-result crash; retain prepared-query coverage and document the application dependency workaround.
 - Preserve shared aggregate/log findings across boots, isolate environment/test sessions, and provide explicit reset and bounded stale-session cleanup (#8).
 - Default to bounded in-memory aggregates, opt into shared file storage, batch each scan into one transaction, and diagnose persistence failures without disrupting application work or N+1 enforcement (#9).

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ With a Content-Security-Policy header (including report-only) or CSP meta tag, t
 
 ### Dashboard
 
-Browse `/__and_one` in development for a full overview of every unique N+1 detected in the current server session. The dashboard shows the query, origin, fix location, and suggested `.includes()` call for each detection.
+Browse `/__and_one` in development for a full overview of every unique N+1 detected in the current server session. The dashboard shows the query, origin, fix location, and suggested `.includes()` call for each detection. Access defaults to loopback peers (`127.0.0.1` or `::1`); missing/remote peer addresses receive 403. See [capture privacy and dashboard access](#capture-privacy-and-dashboard-access) for shared-development setups.
 
 Both features work together: the toast gives you immediate feedback on the page you're looking at, and the dashboard link takes you to the full picture.
 
@@ -307,6 +307,30 @@ Captures are fiber-local; nested captures are inclusive for the parent and indep
 - **Development**: Logs N+1 warnings to Rails logger and stderr
 - **Test**: Raises `AndOne::NPlus1Error` so N+1s fail your test suite
 - **Production**: Disabled by default if loaded; the recommended Gemfile group excludes it
+
+## Capture privacy and dashboard access
+
+The default `AndOne.capture_mode = :redacted` replaces SQL string/numeric/boolean literals, bind placeholders, comments (including hints), and opaque/unterminated tokens with `?` **before retaining samples**. Bind values and lazy bind callbacks are not retained or evaluated. This affects returned detections, callbacks, exceptions, text/JSON output, logs, aggregate storage, and the dashboard—not SQL execution. Fingerprints and query-ignore matching use original SQL before redaction, including occurrences beyond the sample limit. Caller/path/gem ignores inspect the original stack before capture limits.
+
+Each detection retains at most **5 SQL samples × 2,048 bytes** and **20 frames × 256 bytes** in either mode. Frames prioritize application code while preserving stack order. Default frames remove absolute application prefixes; external paths become portable suffixes/filenames. `raw_caller_strings` now means policy-limited strings before optional backtrace cleaning; `caller_locations` contains bounded snapshots with `path`, `absolute_path`, `lineno`, and `to_s` accessors.
+
+Redaction is lexical, not complete anonymization: schema/table/column identifiers and application filenames/method names remain visible. Adapter-specific quoting matters; SQLite/unknown-adapter ambiguous double-quoted values are conservatively masked, which can hide unqualified column names too. Backslashes in quoted tokens conservatively mask the rest of the sample because session-dependent escaping rules can be ambiguous. Avoid embedding secrets in identifiers or using unsupported vendor literal syntax. Do not expose findings publicly or enable production capture on the assumption that redaction removes all sensitive information.
+
+For temporary local debugging only, opt in explicitly **before scanning**:
+
+```ruby
+AndOne.capture_mode = :raw # WARNING: SQL literals and absolute paths can contain credentials/PII
+```
+
+Raw mode remains bounded and does not capture binds. Changing modes cannot revoke already returned detections, callbacks, or written logs. Existing aggregate samples are sanitized when read under redacted mode; old logs/backups must be removed separately. Newly created aggregate, lock, and log files use mode `0600` (aggregate directories use `0700`); existing files' permissions are not automatically changed.
+
+The dashboard returns `Cache-Control: no-store`. It trusts only the direct Rack `REMOTE_ADDR`, not forwarding headers. A local reverse proxy can make remote clients appear local: secure the proxy or supply an explicit guard. For shared development, integrate with trusted authentication middleware **before** DevUI:
+
+```ruby
+AndOne.dashboard_access_guard = ->(env) { env["my_app.authenticated_developer"] == true }
+```
+
+A configured callable replaces the loopback check; false/nil or an exception denies access. Only use server-verified identity, not an arbitrary client header. This is an access hook, not an authentication framework.
 
 ## Configuration
 

--- a/lib/and_one/capture_policy.rb
+++ b/lib/and_one/capture_policy.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "sql_lexer"
+
+module AndOne
+  # Applied before retaining samples, including manually constructed detections.
+  module CapturePolicy
+    MAX_SAMPLES = 5
+    MAX_SQL_BYTES = 2048
+    MAX_FRAMES = 20
+    MAX_FRAME_BYTES = 256
+
+    # Bounded snapshots retain the commonly used Backtrace::Location accessors.
+    Location = Struct.new(:text) do
+      def to_s
+        text
+      end
+
+      def path
+        text.split(/:\d+/, 2).first
+      end
+      alias_method :absolute_path, :path
+
+      def lineno
+        text[/:(\d+)/, 1].to_i
+      end
+    end
+
+    module_function
+
+    def raw?
+      AndOne.respond_to?(:capture_mode) && AndOne.capture_mode == :raw
+    end
+
+    def sql(value, adapter: nil)
+      text = value.to_s
+      text = SqlLexer.new(text, adapter: adapter).redacted unless raw?
+      bounded(text, MAX_SQL_BYTES)
+    rescue ArgumentError
+      "[SQL redacted: invalid encoding]"
+    end
+
+    def frames(values)
+      indexed = values.map(&:to_s).each_with_index.to_a
+      application, internal = indexed.partition { |frame, _index| application_frame?(frame) }
+      (application + internal).first(MAX_FRAMES).sort_by(&:last).map do |text, _index|
+        unless raw?
+          root = defined?(Rails) && Rails.respond_to?(:root) && Rails.root ? Rails.root.to_s : Dir.pwd
+          text = text.delete_prefix("#{root}/")
+          text = text.sub(%r{\A/.*?/(app|lib|test|spec|gems|ruby)/}, '\1/')
+          text = File.basename(text) if text.start_with?("/")
+        end
+        bounded(text, MAX_FRAME_BYTES)
+      end
+    end
+
+    def application_frame?(frame)
+      !frame.match?(%r{(?:\A|/)(?:gems|ruby)/|lib/and_one/|\A<internal:|\(eval\)})
+    end
+
+    def bounded(value, bytes)
+      value.encode("UTF-8", invalid: :replace, undef: :replace).byteslice(0, bytes).scrub("").freeze
+    end
+  end
+end

--- a/lib/and_one/configuration.rb
+++ b/lib/and_one/configuration.rb
@@ -5,6 +5,17 @@ module AndOne
   # replacing it; a failed flush rejects the change rather than losing entries.
   module Configuration
     attr_reader :aggregate_path, :logfile_format, :ignore_file_path, :aggregate_store, :storage_strict
+    attr_accessor :dashboard_access_guard
+
+    def capture_mode
+      @capture_mode || :redacted
+    end
+
+    def capture_mode=(value)
+      raise ArgumentError, "capture_mode must be :redacted or :raw" unless %i[redacted raw].include?(value)
+
+      @capture_mode = value
+    end
 
     %i[aggregate_store storage_strict].each do |setting|
       define_method("#{setting}=") do |value|

--- a/lib/and_one/detection.rb
+++ b/lib/and_one/detection.rb
@@ -3,6 +3,8 @@
 require "digest"
 require "json"
 require_relative "query_cost"
+require_relative "capture_policy"
+require_relative "fingerprint"
 
 module AndOne
   # Represents a single N+1 detection: the repeated queries, their call site, and metadata.
@@ -14,14 +16,17 @@ module AndOne
     def initialize(queries:, count:, caller_locations: nil, raw_caller_strings: nil, adapter: nil, # rubocop:disable Metrics/ParameterLists
                    connection_id: nil, issue_id: nil, fingerprint: nil, query_cost: nil)
       @query_cost = query_cost
-      @queries = queries
-      @caller_locations = caller_locations
-      @raw_caller_strings_override = raw_caller_strings
+      # Compute the legacy broad ignore key before redaction/truncation.
+      @fingerprint = fingerprint || Digest::SHA256.hexdigest(
+        "#{Fingerprint.generate(queries.first, adapter: adapter)}:#{extract_table_name(queries.first)}"
+      )[0, 12]
+      @queries = queries.first(CapturePolicy::MAX_SAMPLES).map { |sql| CapturePolicy.sql(sql, adapter: adapter) }.freeze
+      @raw_caller_strings_override = CapturePolicy.frames(raw_caller_strings || caller_locations&.map(&:to_s) || []).freeze
+      @caller_locations = @raw_caller_strings_override.map { |frame| CapturePolicy::Location.new(frame).freeze }.freeze if caller_locations
       @count = count
       @adapter = adapter
       @connection_id = connection_id
       @issue_id = issue_id
-      @fingerprint = fingerprint
     end
 
     # Returns the SQL of the first query as the representative example
@@ -64,7 +69,7 @@ module AndOne
       [path, line].compact.join(":")
     end
 
-    # The raw caller strings (before backtrace cleaning)
+    # Capture-policy-limited caller strings (before optional backtrace cleaning)
     def raw_caller_strings
       @raw_caller_strings ||= @raw_caller_strings_override || caller_locations&.map(&:to_s) || []
     end
@@ -117,15 +122,7 @@ module AndOne
     end
 
     def app_frame?(frame)
-      # Not a gem
-      !frame.include?("/gems/") &&
-        # Not ruby stdlib / core
-        !frame.include?("/ruby/") &&
-        # Not and_one's own lib code
-        !frame.include?("lib/and_one/") &&
-        # Not <internal: or (eval) type frames
-        !frame.start_with?("<internal:") &&
-        !frame.include?("(eval)")
+      CapturePolicy.application_frame?(frame)
     end
   end
 end

--- a/lib/and_one/detector.rb
+++ b/lib/and_one/detector.rb
@@ -12,7 +12,7 @@ module AndOne
       %r{active_record/validations/uniqueness}
     ].freeze
     SAMPLE_LIMIT = 5
-    Group = Struct.new(:total, :queries, :callers, :metadata, :ignored, :query_cost)
+    Group = Struct.new(:total, :queries, :callers, :metadata, :ignored, :query_cost, :fingerprint)
 
     attr_reader :detections
 
@@ -52,6 +52,7 @@ module AndOne
         Detection.new(
           queries: group.queries,
           caller_locations: group.callers,
+          fingerprint: group.fingerprint,
           count: group.total,
           adapter: group.metadata[:connection_adapter],
           connection_id: group.metadata[:connection_id],
@@ -63,23 +64,27 @@ module AndOne
     def record_query(sql, metadata, duration_ms)
       locations = caller_locations
       key = [location_fingerprint(locations), metadata[:connection_id],
-             Fingerprint.generate(sql, adapter: metadata[:connection_adapter])]
-      group = @groups[key] ||= new_group(locations, metadata)
+             Digest::SHA256.hexdigest(Fingerprint.generate(sql, adapter: metadata[:connection_adapter]))]
+      group = @groups[key] ||= new_group(locations, metadata, sql)
       group.total += 1
       group.query_cost.record(duration_ms)
       # Query ignore rules historically inspect ALL occurrences. Evaluate before
       # dropping samples so a late literal match still suppresses the whole group.
       group.ignored ||= @ignore_list&.query_ignored?(sql)
-      group.queries << sql if group.queries.size < SAMPLE_LIMIT
+      group.queries << CapturePolicy.sql(sql, adapter: metadata[:connection_adapter]) if group.queries.size < SAMPLE_LIMIT
     end
 
-    def new_group(locations, metadata)
-      ignored = locations.any? { |frame| @allow_stack_paths.any? { |pattern| frame.to_s.match?(pattern) } }
-      Group.new(total: 0, queries: [], callers: locations, metadata: metadata, ignored: ignored, query_cost: QueryCost.new)
+    def new_group(locations, metadata, sql)
+      patterns = @allow_stack_paths + (AndOne.ignore_callers || [])
+      ignored = locations.any? { |frame| patterns.any? { |pattern| frame.to_s.match?(pattern) } }
+      ignored ||= @ignore_list&.callers_ignored?(locations.map(&:to_s))
+      sample = Detection.new(queries: [sql], count: 1, adapter: metadata[:connection_adapter])
+      Group.new(total: 0, queries: [], callers: CapturePolicy.frames(locations), metadata: metadata,
+                ignored: ignored, query_cost: QueryCost.new, fingerprint: sample.fingerprint)
     end
 
     def location_fingerprint(locations)
-      locations.map { |loc| [loc.path, loc.lineno] }
+      Digest::SHA256.hexdigest(locations.map { |loc| [loc.path, loc.lineno] }.to_json)
     end
   end
 end

--- a/lib/and_one/dev_ui.rb
+++ b/lib/and_one/dev_ui.rb
@@ -29,10 +29,21 @@ module AndOne
     private
 
     def serve_dashboard(env)
+      return [403, { "content-type" => "text/plain", "cache-control" => "no-store" }, ["Forbidden"]] unless allowed?(env)
+
       entries = sorted_entries(AndOne.aggregate.detections, env["QUERY_STRING"])
 
       html = render_html(entries)
-      [200, { "content-type" => "text/html; charset=utf-8" }, [html]]
+      [200, { "content-type" => "text/html; charset=utf-8", "cache-control" => "no-store" }, [html]]
+    end
+
+    def allowed?(env)
+      guard = AndOne.dashboard_access_guard
+      return !!guard.call(env) if guard
+
+      %w[127.0.0.1 ::1].include?(env["REMOTE_ADDR"])
+    rescue StandardError
+      false
     end
 
     def sorted_entries(entries, query)

--- a/lib/and_one/ignore_file.rb
+++ b/lib/and_one/ignore_file.rb
@@ -47,6 +47,13 @@ module AndOne
       @rules.any? { |rule| rule.type == :query && sql.include?(rule.pattern) }
     end
 
+    def callers_ignored?(frames)
+      @rules.any? do |rule|
+        (rule.type == :gem && matches_gem?(rule.pattern, frames)) ||
+          (rule.type == :path && matches_path?(rule.pattern, frames))
+      end
+    end
+
     private
 
     def parse

--- a/lib/and_one/logfile_writer.rb
+++ b/lib/and_one/logfile_writer.rb
@@ -44,7 +44,7 @@ module AndOne
         return if @entries.empty?
 
         output = "#{format_entries(@entries.values)}\n"
-        FileUtils.mkdir_p(File.dirname(@path))
+        FileUtils.mkdir_p(File.dirname(@path), mode: 0o700)
         append(output)
         @entries.clear
       end

--- a/lib/and_one/sql_lexer.rb
+++ b/lib/and_one/sql_lexer.rb
@@ -15,6 +15,7 @@ module AndOne
       @mysql = adapter.to_s.match?(/mysql|trilogy/i)
       @sqlite = adapter.to_s.match?(/sqlite/i)
       @postgres = adapter.to_s.match?(/postgres/i)
+      @ambiguous_quotes = @sqlite || adapter.nil? || adapter.to_s == "unknown"
     end
 
     def tokens
@@ -28,7 +29,38 @@ module AndOne
       result
     end
 
+    # Preserve SQL layout for display, but never emit literals, comments or
+    # unsupported/unterminated tokens. Fingerprinting intentionally differs.
+    def redacted
+      @redacting = true
+      output = +""
+      previous = nil
+      until @scanner.eos?
+        whitespace = @scanner.scan(/\s+/)
+        if whitespace
+          output << whitespace
+          next
+        end
+        start = @scanner.pos
+        token = next_token
+        output << if token.nil? || %i[parameter opaque].include?(token.kind) || ambiguous_identifier?(token, previous)
+                    "?"
+                  else
+                    @scanner.string.byteslice(start...@scanner.pos)
+                  end
+        previous = token if token
+      end
+      output
+    end
+
     private
+
+    def ambiguous_identifier?(token, previous)
+      return false unless @ambiguous_quotes && token.kind == :identifier && token.text.start_with?('"')
+      return false if @scanner.check(/\s*\./) || previous&.text == "."
+
+      !%w[from join as].include?(previous&.text)
+    end
 
     def next_token
       return block_comment if @scanner.peek(2) == "/*"
@@ -77,6 +109,9 @@ module AndOne
       prefix = @scanner.scan(/[eEnNbBxX](?=')/)
       escaped = @mysql || prefix&.casecmp?("e")
       closed = consume_quoted?("'", escaped: escaped)
+      # Session-dependent backslash rules can make the closing quote ambiguous.
+      # Mask the remainder rather than accidentally emitting part of a literal.
+      @scanner.terminate if @redacting && @scanner.string.byteslice(start...@scanner.pos).include?("\\")
       closed ? Token.new(:parameter, "?") : raw_token(start, :opaque)
     end
 
@@ -96,6 +131,10 @@ module AndOne
       opening = @scanner.peek(1)
       closing = opening == "[" ? "]" : opening
       closed = consume_quoted?(closing, escaped: @mysql)
+      if @redacting && @scanner.string.byteslice(start...@scanner.pos).include?("\\")
+        @scanner.terminate
+        return Token.new(:parameter, "?")
+      end
       if closed && @mysql && opening == '"'
         Token.new(:parameter, "?")
       else

--- a/test/test_capture_policy.rb
+++ b/test/test_capture_policy.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestCapturePolicy < Minitest::Test
+  include AndOneTestHelper
+
+  SECRET = "sentinel_private_password"
+
+  def detection(sql = "SELECT * FROM comments WHERE body = '#{SECRET}'", **)
+    AndOne::Detection.new(queries: [sql] * 8, count: 8,
+                          raw_caller_strings: ["/private/#{SECRET}/app/models/post.rb:10:in 'comments'"] * 30,
+                          **)
+  end
+
+  def test_all_default_sinks_exclude_literals_and_absolute_prefixes
+    det = detection
+    AndOne.aggregate.record(det)
+    outputs = [det.inspect, AndOne::Formatter.new.format([det]), AndOne::JsonFormatter.new.format([det]),
+               AndOne.aggregate.summary, File.read(File.join(@aggregate_tmpdir, "aggregate.json")),
+               AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "::1").last.join]
+    %i[text json].each do |format|
+      path = File.join(@aggregate_tmpdir, "#{format}.log")
+      writer = AndOne::LogfileWriter.new(path: path, format: format)
+      writer.record([det])
+      writer.flush!
+      outputs << File.read(path)
+      assert_equal 0, File.stat(path).mode & 0o077
+    end
+    outputs.each { |output| refute_includes output, SECRET }
+    %w[aggregate.json aggregate.lock].each do |name|
+      assert_equal 0, File.stat(File.join(@aggregate_tmpdir, name)).mode & 0o077
+    end
+  end
+
+  def test_dialects_comments_and_unterminated_tokens
+    ["'#{SECRET}'", "E'#{SECRET}'", "$$#{SECRET}$$", "$tag$#{SECRET}$tag$",
+     "'#{SECRET}", "/*+ #{SECRET} */ 42", "/*! #{SECRET} */ 42",
+     "42 -- #{SECRET}", "42 /* #{SECRET} */", "'prefix\\'#{SECRET}'"].each do |literal|
+      refute_includes detection("SELECT * FROM comments WHERE body = #{literal}").sample_query, SECRET
+    end
+    [nil, "sqlite3", "mysql2"].each do |adapter|
+      refute_includes detection("SELECT * FROM comments WHERE body = \"#{SECRET}\"", adapter: adapter).sample_query, SECRET
+    end
+    refute_includes detection("SELECT * FROM comments WHERE body = 42 # #{SECRET}", adapter: "mysql2").sample_query, SECRET
+  end
+
+  def test_session_dependent_backslash_quotes_fail_closed
+    [nil, "sqlite3", "postgresql", "mysql2"].each do |adapter|
+      ["'prefix\\' AND body = '#{SECRET}'", "'prefix\\'#{SECRET}'"].each do |value|
+        refute_includes detection("SELECT * FROM comments WHERE body = #{value}", adapter: adapter).sample_query, SECRET
+      end
+    end
+  end
+
+  def test_detector_never_retains_bind_values_or_literal_samples
+    detector = AndOne::Detector.new
+    3.times do
+      detector.record(sql: "SELECT * FROM comments WHERE body = '#{SECRET}' AND post_id = ?",
+                      binds: [SECRET], type_casted_binds: -> { raise "must not evaluate binds" })
+    end
+    refute_includes detector.instance_variable_get(:@groups).inspect, SECRET
+    assert_equal 3, detector.finish.first.count
+    refute_includes detector.detections.inspect, SECRET
+  end
+
+  def test_limits_apply_to_direct_detections_and_raw_opt_in
+    %i[redacted raw].each do |mode|
+      AndOne.capture_mode = mode
+      det = detection("SELECT * FROM comments #{"x" * 10_000}")
+      assert_equal 5, det.queries.size
+      assert_operator det.sample_query.bytesize, :<=, 2048
+      assert_operator det.raw_caller_strings.size, :<=, 20
+      assert(det.raw_caller_strings.all? { |frame| frame.bytesize <= 256 })
+    end
+    assert_includes detection.sample_query, SECRET
+    assert_includes detection.raw_caller_strings.first, SECRET
+    assert_raises(ArgumentError) { AndOne.capture_mode = :oops }
+  ensure
+    AndOne.capture_mode = :redacted
+  end
+
+  def test_legacy_raw_aggregate_is_redacted_on_read
+    AndOne.capture_mode = :raw
+    AndOne.aggregate.record(detection)
+    AndOne.capture_mode = :redacted
+    refute_includes AndOne.aggregate.detections.inspect, SECRET
+    refute_includes File.read(File.join(@aggregate_tmpdir, "aggregate.json")), SECRET
+  end
+
+  def test_ignores_see_original_values_and_full_callers_before_capture
+    path = File.join(@aggregate_tmpdir, "ignore")
+    File.write(path, "query:#{SECRET}\n")
+    detector = AndOne::Detector.new(ignore_list: AndOne::IgnoreFile.new(path))
+    8.times { |i| detector.record(sql: "SELECT * FROM comments WHERE body = '#{i == 7 ? SECRET : "ordinary"}'") }
+    assert_empty detector.finish
+
+    AndOne.ignore_callers = [%r{/private/#{SECRET}/}]
+    detector = AndOne::Detector.new
+    frames = [AndOne::CapturePolicy::Location.new("/private/#{SECRET}/app/models/post.rb:10")]
+    detector.stub(:caller_locations, frames) do
+      3.times { detector.record(sql: "SELECT * FROM comments WHERE post_id = 1") }
+    end
+    assert_empty detector.finish
+  end
+
+  def test_raw_mode_remains_html_escaped
+    AndOne.capture_mode = :raw
+    AndOne.aggregate.record(detection("SELECT * FROM comments WHERE body = '<script>alert(1)</script>'"))
+    html = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1").last.join
+    refute_includes html, "<script>"
+    assert_includes html, "&lt;script&gt;"
+  ensure
+    AndOne.capture_mode = :redacted
+  end
+
+  def test_dashboard_guard_defaults_and_override
+    ui = AndOne::DevUI.new(nil)
+    [nil, "192.0.2.1", "localhost"].each do |address|
+      status, headers, body = ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => address,
+                                      "HTTP_X_FORWARDED_FOR" => "127.0.0.1")
+      assert_equal 403, status
+      assert_equal "no-store", headers["cache-control"]
+      assert_equal ["Forbidden"], body
+    end
+    %w[127.0.0.1 ::1].each do |address|
+      assert_equal 200, ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => address).first
+    end
+    AndOne.dashboard_access_guard = ->(env) { env["trusted.user"] == "developer" }
+    assert_equal 403, ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1").first
+    assert_equal 200, ui.call("PATH_INFO" => "/__and_one", "trusted.user" => "developer").first
+    AndOne.dashboard_access_guard = ->(_env) { raise "guard failed" }
+    assert_equal 403, ui.call("PATH_INFO" => "/__and_one").first
+  ensure
+    AndOne.dashboard_access_guard = nil
+  end
+end

--- a/test/test_dev_ui.rb
+++ b/test/test_dev_ui.rb
@@ -21,7 +21,7 @@ class TestDevUI < Minitest::Test
     app = ->(_env) { [200, {}, ["app"]] }
     dev_ui = AndOne::DevUI.new(app)
 
-    status, headers, body = dev_ui.call("PATH_INFO" => "/__and_one")
+    status, headers, body = dev_ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1")
 
     assert_equal 200, status
     assert_equal "text/html; charset=utf-8", headers["content-type"]
@@ -47,7 +47,7 @@ class TestDevUI < Minitest::Test
     app = ->(_env) { [200, {}, ["app"]] }
     dev_ui = AndOne::DevUI.new(app)
 
-    _status, _headers, body = dev_ui.call("PATH_INFO" => "/__and_one")
+    _status, _headers, body = dev_ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1")
 
     html = body.first
     assert_includes html, "comments"
@@ -58,7 +58,7 @@ class TestDevUI < Minitest::Test
     app = ->(_env) { [200, {}, ["app"]] }
     dev_ui = AndOne::DevUI.new(app)
 
-    _status, _headers, body = dev_ui.call("PATH_INFO" => "/__and_one")
+    _status, _headers, body = dev_ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1")
 
     html = body.first
     assert_includes html, "No N+1 queries detected yet"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,6 +68,8 @@ module AndOneTestHelper
   def setup
     super
     AndOne.enabled = true
+    AndOne.capture_mode = :redacted
+    AndOne.dashboard_access_guard = nil
     AndOne.raise_on_detect = false
     AndOne.allow_stack_paths = []
     AndOne.ignore_queries = []

--- a/test/test_issue_identity.rb
+++ b/test/test_issue_identity.rb
@@ -71,7 +71,7 @@ class TestIssueIdentity < Minitest::Test
     assert_equal([first.issue_id, other.issue_id], json.map { |entry| entry[:issue_id] })
     assert_equal [first.fingerprint], json.map { |entry| entry[:fingerprint] }.uniq
     text = AndOne::Formatter.new.format([first, other])
-    html = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one").last.join
+    html = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1").last.join
     [text, html, AndOne.aggregate.summary].each do |output|
       [first, other].each do |finding|
         assert_includes output, finding.issue_id

--- a/test/test_query_cost.rb
+++ b/test/test_query_cost.rb
@@ -136,7 +136,7 @@ class TestQueryCost < Minitest::Test
       "queries" => %w[many frequent expensive historical],
       "occurrences" => %w[frequent expensive historical many],
       "invalid" => %w[expensive many frequent historical] }.each do |sort, expected|
-      html = ui.call("PATH_INFO" => "/__and_one", "QUERY_STRING" => "sort=#{sort}")[2].first
+      html = ui.call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1", "QUERY_STRING" => "sort=#{sort}")[2].first
       assert_equal expected, html.scan(/issue_id: (\w+)/).flatten
       assert_includes html, "300.000 ms observed"
       assert_includes html, "Unknown (historical)"

--- a/test/test_recommendations.rb
+++ b/test/test_recommendations.rb
@@ -103,7 +103,7 @@ class TestRecommendations < Minitest::Test
     assert_equal "guidance_only", json[:suggestion][:confidence]
 
     AndOne.aggregate.record(detection)
-    _, _, body = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one")
+    _, _, body = AndOne::DevUI.new(nil).call("PATH_INFO" => "/__and_one", "REMOTE_ADDR" => "127.0.0.1")
     assert_includes body.join, "Possible fix location (heuristic)"
     assert_includes body.join, "counter cache"
 


### PR DESCRIPTION
## Summary
Closes #10. Keeps dependent classification work (#21) out of this PR, as requested by both issues.

- Apply a shared capture policy before retaining detector samples and when constructing/deserializing detections; bound samples and portable backtrace snapshots in both redacted and explicit raw modes.
- Mask SQL literals/comments/opaque tokens, ambiguous SQLite double quotes, and session-dependent backslash tails; never retain or evaluate bind values. Hash group keys and preserve original-SQL fingerprints and pre-redaction query/caller ignores.
- Default dashboard access to direct loopback peers, with a configurable fail-closed guard and no-store responses; retain HTML escaping.
- Keep restrictive file permissions, restrict new logfile directories, and document raw-capture risks, compatibility changes, proxy considerations, and lexical-redaction limitations.

## Validation
- `bundle exec rake test`: 320 runs, 1,784 assertions, no failures/errors/skips.
- `bundle exec rubocop`: 89 files, no offenses.
- `git diff --check`: clean.
- Added regressions for sentinel secrets across storage/text/JSON/log/dashboard sinks, bind callbacks, dialect and ambiguous quoting, capture limits, legacy raw aggregate migration, permissions, original-value ignores, access guards, and raw-mode HTML escaping.

Redaction deliberately retains schema identifiers and portable application filenames/method names; it is not complete anonymization. The README documents this boundary and the need to secure local reverse proxies.