### PR TITLE
Add GitHub Pages marketing site and streamline documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy marketing site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,264 +1,67 @@
 # 🏀 AndOne
 
-Detect N+1 queries in Rails applications with zero configuration and actionable fix suggestions.
+Find repeated ActiveRecord queries in Rails, investigate likely N+1s, and catch query regressions in tests. No external service required.
 
-AndOne stays completely invisible until it detects an N+1 query — then it points to repeated queries and suggests what to investigate. No external dependencies beyond Rails itself.
-
-## Features
-
-- **Zero configuration** — Railtie auto-setup in development and test
-- **Qualified fix suggestions** — suggests candidate `.includes()`/`.preload()` calls for basic association record loading, with separate guidance for counts and scalar queries
-- **Location hints** — shows the origin and a heuristic caller location to investigate (not the proven relation-construction site)
-- **Clean error handling** — never corrupts backtraces or interferes with exception propagation
-- **No external dependencies** — only Rails itself
-- **Auto-raises in test** — N+1s fail your test suite by default
-- **Background job support** — ActiveJob (`around_perform`) and Sidekiq server middleware, with double-scan protection
-- **Ignore file** — `.and_one_ignore` with `gem:`, `path:`, `query:`, and `fingerprint:` rules
-- **Bounded deduplication** — occurrence counts with in-memory storage by default and opt-in shared, session-scoped file storage
-- **Test matchers** — Minitest (`assert_no_n_plus_one`) and RSpec (`expect { }.not_to cause_n_plus_one`)
-- **Dev toast notifications** — in-page toast on every page that triggers an N+1, with a link to the dashboard
-- **Dev UI dashboard** — browse `/__and_one` in development; rank findings by observed SQL time, occurrences, or executed query count
-- **Rails console integration** — auto-scans in `rails console` and prints warnings inline
-- **Structured JSON logging** — JSON output mode for Datadog, Splunk, and other log aggregation services
-- **Per-environment thresholds** — different `min_n_queries` for development vs test
-- **GitHub Actions annotations** — N+1s appear as warning annotations on PR diffs
-- **`strict_loading` suggestions** — also suggests model-level prevention as an alternative
-- **Conservative association resolution** — handles unambiguous `belongs_to`, `has_one`, and `has_many`; abstains on complex or ambiguous SQL
-- **Isolated capture** — one SQL subscriber, fiber-local scans, and bounded representative query samples; verified with concurrent stress tests
-
-## Finding classification
-
-Repeated SQL is evidence, not proof of an association N+1. Findings expose `kind` and `confidence` (symbols in Ruby, strings in JSON):
-
-| Kind | Confidence | Evidence |
-|---|---|---|
-| `suspected_association_n_plus_one` | `candidate` | Varying value signatures in simple record SELECTs with qualified equality/IN predicates |
-| `duplicate_identical_read` | `observed` | All executed reads have identical lexical SQL/value signatures |
-| `repeated_aggregate` | `observed` | COUNT, SUM/AVG/MIN/MAX, or EXISTS-style projection; no record-preload advice |
-| `generic_repetition` | `unknown` | Missing/unsupported evidence, scalar or complex varying reads |
-
-Signatures use a random per-scan HMAC key and retain only one digest per group, never raw bind values. Already materialized primitive `type_casted_binds` arrays can be compared; lazy callbacks and bind objects are never evaluated. Literal SQL is compared only where lexical evidence is supported. Missing evidence on even a late occurrence makes value-based classification abstain. See [signature bounds and limitations](docs/capture.md#classification-evidence).
-
-Variation is across the **whole value vector**, not proof of different parents or Ruby association calls. Intentional batching can still produce findings. Identical reads need not return identical results or be safe to cache. Existing thresholds, ignores, counts, fingerprints, issue IDs, `NPlus1Error`, matchers, and the legacy JSON event name remain unchanged: enforcement still applies to **all** finding kinds. Aggregate classification describes its retained representative scan, not merged evidence across requests; older/manual detections default to generic/unknown.
-
-## Recommendation limits
-
-SQL alone does not prove which Ruby association was called. Association advice uses currently loaded models and qualified equality/`IN` predicates in plain, single-table SELECTs. Both foreign keys and `belongs_to` target primary keys (including custom single-column keys) are considered. Multiple matching associations/models, through associations, polymorphic associations, joins, aliases, CTEs, composite keys, and other complex SQL may receive only non-actionable guidance. Models and reflections are not cached: late-loaded models and Rails-reloaded classes are considered on the next resolution without retaining stale misses/classes.
-
-For basic record loading, try the suggested `includes` or `preload` on the parent relation and verify equivalent scopes/results and fewer queries. Filters or AND/OR tokens do **not** establish that a JOIN is faster. COUNT receives counter-cache/grouped-count guidance: `includes` alone does not eliminate association `.count` queries; `.size` can reuse an already loaded association when loading all its records is acceptable. Existence and scalar lookups receive batching guidance rather than an invented association fix. `strict_loading` hints apply to lazy record loading, not count/existence queries.
-
-The possible fix location is a **heuristic** caller frame, not necessarily where the relation was constructed. Text, dashboard, and GitHub annotations label it accordingly; JSON retains `fix_location` and adds `fix_location_confidence: "heuristic"`. JSON suggestions include `operation`, `association_type`, and `confidence` (`candidate` or `guidance_only`); guidance-only entries may have a null association/loading strategy.
+AndOne reports query counts, observed SQL time, call sites, and qualified fix suggestions. **Repeated SQL is evidence, not proof of an association N+1**: findings distinguish suspected association loading, identical reads, aggregates, and generic repetition.
 
 ## Installation
 
-Add to your Gemfile:
-
 ```ruby
+# Gemfile
 group :development, :test do
   gem "and_one"
 end
 ```
 
-That's it. AndOne automatically activates in development and test environments via a Railtie.
+Requires **Ruby 3.2+ and Rails components 7.0+**, using mutually compatible versions. Rails installs request and job hooks automatically:
 
-## Ruby and ORM support
-
-AndOne requires Ruby 3.2+ and ActiveRecord/ActiveSupport/Railties 7.0+ (choose versions compatible with your Ruby). Rails applications get automatic request/job integration. Outside a Rails application, “plain Ruby” support means **ActiveRecord SQL instrumentation**, not arbitrary database clients or other ORMs such as Sequel. Railties remains a runtime dependency; RSpec is optional and only needed for `and_one/rspec`. No public RBS signatures are currently shipped.
-
-CI exercises Ruby/Rails 3.2/7.0, 3.3/7.2, and 4.0/8.1 on SQLite, plus the oldest/current boundaries on PostgreSQL 16 and MySQL 8.0. A 17-scenario labeled corpus checks recommendation accuracy, known limitations, and before/after result equivalence and physical query counts. See [the support matrix and local reproduction commands](docs/compatibility.md).
-
-A standalone script can use:
-
-```ruby
-require "and_one"       # loads its ActiveRecord and Railtie dependencies itself
-require "sqlite3"       # install your chosen database adapter separately
-
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "app.sqlite3")
-# Define/load your ActiveRecord models, e.g. Post has_many :comments.
-AndOne.configure do |config|
-  config.enabled = true
-  config.raise_on_detect = false
-end
-
-detections = AndOne.scan do
-  Post.all.each { |post| post.comments.to_a }
-end
-puts "Detected #{detections.size} repeated-query patterns"
-```
-
-Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans keep bounded findings in memory by default; set `aggregate_store = :file` before the first scan for process sharing. `require "and_one"` is safe before or after loading Rails.
-
-## Capture coverage and limits
-
-Scans capture synchronous ActiveRecord SQL in the **current fiber**. Child fibers/threads do not inherit scans; start independent scans inside them if needed. Async-tagged SQL is excluded because Rails may publish worker notifications later in an unrelated consumer's scan. Synchronous `load_async` fallback is captured normally. Lazy response-body SQL is outside request scan coverage.
-
-One process-level subscriber routes events to the active context. Each repeated shape/location retains its first five SQL samples plus an exact total count: `Detection#queries` is a sample, while `Detection#count` includes all eligible occurrences. Query-ignore rules still inspect every occurrence. Unique groups and individual SQL sizes are not capped.
-
-Findings expose `query_cost` timing summaries from monotonic SQL notifications; aggregate entries roll them up across repeated occurrences. Cache hits and async work are excluded, and historical missing costs remain unknown. These are observed costs, not estimated savings. JSON rollups are available through `AndOne::JsonFormatter.new.format_aggregate(AndOne.aggregate.detections)`.
-
-See [capture boundaries, measured costs, retention, and benchmark commands](docs/capture.md) for details.
-
-## What You'll See
-
-When an N+1 is detected, you get output like:
-
-```
-──────────────────────────────────────────────────────────────────────────
- 🏀 And One! 1 repeated-query finding detected
-──────────────────────────────────────────────────────────────────────────
-
-  1) 9x repeated query on `comments`
-     suspected association N+1 (candidate)
-     fingerprint: a1b2c3d4e5f6
-
-  Query:
-    SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?
-
-  Origin (where the repeated query is triggered):
-  → app/views/posts/index.html.erb:5
-
-  Possible fix location (heuristic; inspect the caller):
-  ⇒ app/controllers/posts_controller.rb:8
-
-  Call stack:
-    app/views/posts/index.html.erb:5
-    app/controllers/posts_controller.rb:8
-
-  💡 Suggestion:
-    If this is Post#comments record loading, try `.includes(:comments)` or `.preload(:comments)` on the parent query; verify scopes and results.
-
-  To ignore, add to .and_one_ignore:
-    fingerprint:a1b2c3d4e5f6
-
-──────────────────────────────────────────────────────────────────────────
-```
-
-## Background Jobs
-
-### ActiveJob (any backend)
-
-Automatically hooked via `around_perform`. Works with **every** ActiveJob backend:
-Sidekiq, GoodJob, SolidQueue, Delayed Job, Resque, and anything else that uses ActiveJob.
-
-No configuration needed — the Railtie handles it.
-
-### Sidekiq (direct usage)
-
-For jobs that use Sidekiq directly (bypassing ActiveJob), AndOne installs a server middleware automatically when Sidekiq is detected.
-
-If you need manual installation:
-
-```ruby
-Sidekiq.configure_server do |config|
-  config.server_middleware do |chain|
-    chain.add AndOne::SidekiqMiddleware
-  end
-end
-```
-
-When both hooks are active (ActiveJob job running through Sidekiq), the Sidekiq middleware detects the existing scan from ActiveJobHook and passes through — no double-scanning.
-
-## Ignoring N+1s
-
-### The `.and_one_ignore` file
-
-Create a `.and_one_ignore` file in your project root to permanently silence known N+1s. Supports four rule types:
-
-```bash
-# Ignore N+1s originating from a specific gem
-# (matches against raw backtrace paths, e.g. /gems/devise-4.9.0/)
-gem:devise
-gem:administrate
-
-# Ignore N+1s whose call stack matches a path pattern (supports * globs)
-path:app/views/admin/*
-path:lib/legacy/**
-
-# Ignore N+1s matching a SQL pattern
-query:schema_migrations
-query:pg_catalog
-
-# Ignore a query shape at all locations by its fingerprint (shown in output)
-fingerprint:a1b2c3d4e5f6
-```
-
-This is especially useful for **N+1s coming from gems** where you can't add `.includes()` to the source. Instead of littering your code with `AndOne.pause` blocks, add a `gem:` rule.
-
-### When to use each rule type
-
-| Rule | Use when... |
+| Environment | Default behavior |
 |---|---|
-| `gem:devise` | A gem you depend on has an N+1 you can't fix |
-| `path:app/views/admin/*` | An area of your app has known N+1s you've accepted |
-| `query:some_table` | A specific query pattern should always be ignored |
-| `fingerprint:abc123` | You want to silence a query shape at all locations/connections |
+| Development | Log findings, show in-page notices, and enable `/__and_one` |
+| Test | Raise `AndOne::NPlus1Error` on every scan with findings |
+| Production | Disabled if loaded; the Gemfile group above excludes it |
 
-## Deduplication
+ActiveJob is supported across backends; direct Sidekiq jobs are hooked when Sidekiq is loaded at Railtie setup. Nested hooks reuse the existing scan. Development Rails consoles are scanned automatically.
 
-In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique issue (query shape + application origin + connection context) is reported only once while retained in the aggregate (per process by default, or across cooperating processes with file storage). Subsequent occurrences at that location are silently counted; the same SQL shape at a different location remains visible as a separate issue.
+Standalone scripts can use `AndOne.scan` with ActiveRecord; arbitrary database clients and other ORMs are not supported. See [standalone setup and tested versions](docs/usage.md#ruby-and-orm-support).
 
-Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan. Test matchers do not report or consume first-occurrence deduplication.
+## What you get
 
-You can check the session summary at any time:
+- **Actionable investigation:** candidate `.includes()`/`.preload()` advice for simple association record loading; separate guidance for counts, existence checks, scalar queries, and duplicate reads.
+- **Location hints:** the query origin and a heuristic caller to inspect—not a proven relation-construction site.
+- **Measured impact:** exact eligible query counts and observed SQL notification time, not estimated savings.
+- **Development dashboard:** browse `/__and_one`; sort retained findings by cumulative SQL time, occurrences, or executed query count.
+- **Test helpers:** repeated-query matchers, physical query budgets, and input-growth assertions for Minitest and RSpec.
+- **Reporting:** text or JSON logs, callbacks, GitHub Actions warning annotations, and first-occurrence deduplication.
+- **Private, bounded samples:** SQL literals redacted by default; bind values never retained.
 
-```ruby
-AndOne.aggregate.summary    # formatted string of all unique N+1s
-AndOne.aggregate.size       # number of unique issues
-AndOne.aggregate.detections # { issue_id => Entry }; entry.detection.fingerprint is the broad ignore key
-AndOne.aggregate.reset!     # clear and start fresh
-```
+Toasts appear at **top-right** on eligible buffered HTML responses. Streaming, compressed, download, and non-HTML responses are left untouched. Under CSP, a script-free `<details>` notice replaces the styled toast. [UI details](docs/usage.md#development-ui).
 
-Output includes a location-aware `issue_id` alongside the unchanged broad `fingerprint` ignore key. Stored entries retain both identities. Old shape-keyed entries are migrated using their retained location; reset once on upgrade to avoid duplicate historical entries without connection metadata. See [identity and eligibility limits](docs/sql-fingerprints.md#query-shape-versus-issue-identity).
+## Finding classification
 
-SQL normalization version 2 can change detection fingerprints. When upgrading, reset stale aggregate data and regenerate affected `fingerprint:` ignore entries. See [SQL fingerprints](docs/sql-fingerprints.md) for supported syntax, dialect limitations, and migration steps.
+| Kind | Confidence | Meaning |
+|---|---|---|
+| `suspected_association_n_plus_one` | `candidate` | Varying values in simple record reads with qualified equality/IN predicates |
+| `duplicate_identical_read` | `observed` | Identical lexical SQL/value signatures in non-aggregate reads |
+| `repeated_aggregate` | `observed` | Repeated COUNT, SUM/AVG/MIN/MAX, or EXISTS-style projection |
+| `generic_repetition` | `unknown` | Unsupported, missing, scalar, or complex evidence |
 
-## Development UI
+Classification uses bounded, per-scan HMAC signatures when value evidence is available; it never evaluates lazy bind callbacks. Intentional batching can still produce findings, and identical reads are not necessarily safe to cache. **Thresholds, ignores, test matchers, and `NPlus1Error` apply to all finding kinds.**
 
-### In-page toast notifications
+Association suggestions are candidates to verify, not automatic fixes. Ambiguous associations or complex SQL may receive only general guidance. `includes` alone does not fix association `.count` queries. See [classification evidence](docs/capture.md#classification-evidence) and [recommendation limits](docs/usage.md#recommendation-limits).
 
-When an N+1 is detected during a request, AndOne injects a small toast notification into the bottom-right corner of the page. The toast shows which tables were affected and links to the full dashboard for details.
-
-This is enabled by default in development — no configuration needed. The toast auto-dismisses after 8 seconds, but hovering over it keeps it open.
-
-To change the position or disable it:
-
-```ruby
-# config/initializers/and_one.rb
-AndOne.dev_toast_position = :bottom_right  # :top_right (default), :top_left, :bottom_right, :bottom_left
-AndOne.dev_toast = false                   # disable entirely
-```
-
-The toast only transforms complete `text/html` responses with status 200 and a Rack `to_ary` body (including ordinary Rails renders). HEAD, API, redirect, error, encoded/compressed, streaming, file/download, and partial responses are left untouched. Place AndOne inside compression middleware to inject before compression. Transformed responses lose Content-Length and validators/digests; untouched content keeps its metadata. Rack bodies own cleanup in `to_ary`, including on conversion errors; AndOne does not enumerate arbitrary bodies or close converted bodies a second time.
-
-With a Content-Security-Policy header (including report-only) or CSP meta tag, the toast becomes an unstyled, script-free native `<details>` notice with a dashboard link. It does not auto-dismiss or use the position setting, and never requires `unsafe-inline` or changes your policy.
-
-**SQL coverage:** scanning ends when the application returns its Rack response, before lazy body enumeration. Queries executed by streaming/lazy bodies are not captured by this middleware; use an explicit scan within that workload if needed.
-
-### Dashboard
-
-Browse `/__and_one` in development for a full overview of every unique N+1 detected in the current server session. The dashboard shows the query, origin, fix location, and suggested `.includes()` call for each detection. Access defaults to loopback peers (`127.0.0.1` or `::1`); missing/remote peer addresses receive 403. See [capture privacy and dashboard access](#capture-privacy-and-dashboard-access) for shared-development setups.
-
-Both features work together: the toast gives you immediate feedback on the page you're looking at, and the dashboard link takes you to the full picture.
-
-## Test Matchers
+## Test query behavior
 
 ### Minitest
 
 ```ruby
-class PostsControllerTest < ActionDispatch::IntegrationTest
+class PostsTest < ActiveSupport::TestCase
   include AndOne::MinitestHelper
 
-  test "index does not cause N+1 queries" do
+  test "preloads comments" do
     assert_no_n_plus_one do
-      get posts_path
+      Post.preload(:comments).each { |post| post.comments.to_a }
     end
-  end
-
-  test "known N+1 is documented" do
-    detections = assert_n_plus_one do
-      get legacy_report_path
-    end
-    assert_equal "comments", detections.first.table_name
   end
 end
 ```
@@ -266,208 +69,112 @@ end
 ### RSpec
 
 ```ruby
-# In spec_helper.rb or rails_helper.rb
-require "and_one/rspec" # loads RSpec core and registers the helper, in either require order
+require "and_one/rspec"
 
-# Then in your specs
-RSpec.describe "Posts" do
-  it "loads posts efficiently" do
+RSpec.describe Post do
+  it "preloads comments" do
     expect {
-      Post.includes(:comments).each { |p| p.comments.to_a }
+      Post.preload(:comments).each { |post| post.comments.to_a }
     }.not_to cause_n_plus_one
-  end
-
-  it "has a known N+1" do
-    expect {
-      Post.all.each { |p| p.comments.to_a }
-    }.to cause_n_plus_one
   end
 end
 ```
 
-N+1 matchers capture a non-reporting scan: they never change global configuration, invoke callbacks, write findings, or raise `NPlus1Error`. Other concurrent scans retain their configured reporting and enforcement. Ignores and `enabled = false` still apply (disabled matchers execute the block but see no detections).
+These matchers respect ignores and `enabled`, but do not log, invoke callbacks, change deduplication, or raise `NPlus1Error`. Put them **around** requests/jobs, not inside an already active scan.
 
-Starting an N+1 matcher inside an already active scan raises `ArgumentError` **before executing its block**. Put the matcher around the request/job or scan instead; ordinary nested request/job scans still pass through to the matcher's scope. Both successful Minitest helpers count one assertion.
-
-### Physical query budgets and input growth
-
-These explicit measurements count database work independently of repeated-shape detection:
+### Query budgets and growth
 
 ```ruby
-# Create fixtures and warm schema/connection caches BEFORE these scopes.
-# Workloads must build fresh relations/records, not reuse loaded associations.
+# Prepare sufficient records and warm schema/connection caches first.
 small = -> { Post.limit(2).preload(:comments).each { |p| p.comments.to_a } }
 large = -> { Post.limit(20).preload(:comments).each { |p| p.comments.to_a } }
 
-# Minitest (include AndOne::MinitestHelper)
-result = assert_query_budget(max: 2, &large)
-result.count         # executed query count
-result.cached_count  # cache hits, excluded from the budget
-result.locations     # up to five query call sites, no SQL/bind values
-result = assert_query_growth(small: small, large: large, max_growth: 0)
-result.growth        # large.count - small.count
+# Minitest
+assert_query_budget(max: 2, &large)
+assert_query_growth(small: small, large: large, max_growth: 0)
 
-# RSpec (require "and_one/rspec")
+# RSpec
 expect(&large).to stay_within_query_budget(2)
 expect(small: small, large: large).to stay_within_query_growth(0)
 ```
 
-Limits are non-negative integers and inclusive. Growth measures the **absolute increase** in query count, not a ratio or timing: a bound of zero requires constant or decreasing counts. Each supplied workload runs exactly once, small before large; the library never creates fixtures, warms up, clears caches, or silently reruns your block. Choose genuinely different input sizes and prepare sufficient data yourself. Setup performed inside a workload is counted.
-
-Counts include non-cached `sql.active_record` events, including reads, writes, and transaction statements, but exclude `SCHEMA` events and empty SQL. Cache hits are counted separately. Existing cache state is preserved: for cold-query regression tests wrap the assertions in `ActiveRecord::Base.uncached`; for warm-cache tests warm up explicitly outside measurement. These are notification counts, not network round trips (e.g. a multi-statement event counts once).
-
-Captures are fiber-local; nested captures are inclusive for the parent and independent for the child. Exceptions and nonlocal exits restore the parent scope. Child fibers, threads, and asynchronous queries are not included. Unlike N+1 matchers, these explicit counts remain active when AndOne is disabled/paused and do not apply ignores or detection thresholds. They neither start an N+1 scan nor change reporting settings: existing or nested application scans retain their normal enforcement and can still raise `NPlus1Error`. Failures show small/large counts and bounded query locations without retaining SQL or bind values. Query budgets complement, rather than prove the absence of, N+1 behavior.
-
-## Behavior by Environment
-
-- **Development**: Logs N+1 warnings to Rails logger and stderr
-- **Test**: Raises `AndOne::NPlus1Error` so N+1s fail your test suite
-- **Production**: Disabled by default if loaded; the recommended Gemfile group excludes it
-
-## Capture privacy and dashboard access
-
-The default `AndOne.capture_mode = :redacted` replaces SQL string/numeric/boolean literals, bind placeholders, comments (including hints), and opaque/unterminated tokens with `?` **before retaining samples**. Bind values are never retained; already materialized primitive arrays may be hashed for classification. Lazy bind callbacks are never evaluated. This affects returned detections, callbacks, exceptions, text/JSON output, logs, aggregate storage, and the dashboard—not SQL execution. Fingerprints and query-ignore matching use original SQL before redaction, including occurrences beyond the sample limit. Caller/path/gem ignores inspect the original stack before capture limits.
-
-Each detection retains at most **5 SQL samples × 2,048 bytes** and **20 frames × 256 bytes** in either mode. Frames prioritize application code while preserving stack order. Default frames remove absolute application prefixes; external paths become portable suffixes/filenames. `raw_caller_strings` now means policy-limited strings before optional backtrace cleaning; `caller_locations` contains bounded snapshots with `path`, `absolute_path`, `lineno`, and `to_s` accessors.
-
-Redaction is lexical, not complete anonymization: schema/table/column identifiers and application filenames/method names remain visible. Adapter-specific quoting matters; SQLite/unknown-adapter ambiguous double-quoted values are conservatively masked, which can hide unqualified column names too. Backslashes in quoted tokens conservatively mask the rest of the sample because session-dependent escaping rules can be ambiguous. Avoid embedding secrets in identifiers or using unsupported vendor literal syntax. Do not expose findings publicly or enable production capture on the assumption that redaction removes all sensitive information.
-
-For temporary local debugging only, opt in explicitly **before scanning**:
-
-```ruby
-AndOne.capture_mode = :raw # WARNING: SQL literals and absolute paths can contain credentials/PII
-```
-
-Raw mode remains bounded and does not capture binds. Changing modes cannot revoke already returned detections, callbacks, or written logs. Existing aggregate samples are sanitized when read under redacted mode; old logs/backups must be removed separately. Newly created aggregate, lock, and log files use mode `0600` (aggregate directories use `0700`); existing files' permissions are not automatically changed.
-
-The dashboard returns `Cache-Control: no-store`. It trusts only the direct Rack `REMOTE_ADDR`, not forwarding headers. A local reverse proxy can make remote clients appear local: secure the proxy or supply an explicit guard. For shared development, integrate with trusted authentication middleware **before** DevUI:
-
-```ruby
-AndOne.dashboard_access_guard = ->(env) { env["my_app.authenticated_developer"] == true }
-```
-
-A configured callable replaces the loopback check; false/nil or an exception denies access. Only use server-verified identity, not an arbitrary client header. This is an access hook, not an authentication framework.
+Budgets count non-cached synchronous SQL notifications, including writes and transactions, but not schema events. Growth is `large.count - small.count`, not a ratio. Each workload runs once; AndOne does not create data, warm up, or clear caches. These measurements remain active when detection is disabled/paused and do not suppress normal scan enforcement. [Full test-helper semantics](docs/usage.md#test-matchers).
 
 ## Configuration
 
-AndOne works out of the box, but you can customize:
+Configure in `config/initializers/and_one.rb`, before scanning:
 
 ```ruby
-# config/initializers/and_one.rb
 AndOne.configure do |config|
-  # Raise on detection (default: true in test, false in development)
-  config.raise_on_detect = false
+  config.min_n_queries = 2                  # default repetition threshold
+  config.env_thresholds = { development: 3, test: 2 }
+  config.raise_on_detect = Rails.env.test?  # Rails default
+  config.dev_toast_position = :top_right    # default; or :top_left/:bottom_right/:bottom_left
+  config.capture_mode = :redacted           # default; :raw is for trusted local debugging only
 
-  # Minimum repeated queries to trigger (default: 2)
-  config.min_n_queries = 3
+  # Optional: share aggregate findings across cooperating processes.
+  # config.aggregate_store = :file          # default: bounded process-local memory
 
-  # In-page toast notifications (default: true in development)
-  config.dev_toast = true
-
-  # Toast position (default: :top_right)
-  # Options: :top_right, :top_left, :bottom_right, :bottom_left
-  config.dev_toast_position = :top_right
-
-  # Opt in to process sharing (default: bounded in-memory storage)
-  config.aggregate_store = :file
-
-  # Optional exact custom directory; also opts into file storage.
-  # Custom paths bypass automatic environment/session isolation.
-  # config.aggregate_path = Rails.root.join("tmp", "my_findings").to_s
-
-  # Raise storage errors instead of diagnosing them (default: false)
-  config.storage_strict = false
-
-  # Path to ignore file (default: Rails.root/.and_one_ignore)
-  config.ignore_file_path = Rails.root.join(".and_one_ignore").to_s
-
-  # Allow specific patterns (won't flag these call stacks)
-  config.allow_stack_paths = [
-    /admin_controller/,
-    /some_legacy_code/
-  ]
-
-  # Ignore specific query patterns
-  config.ignore_queries = [
-    /pg_catalog/,
-    /schema_migrations/
-  ]
-
-  # Custom backtrace cleaner
-  config.backtrace_cleaner = Rails.backtrace_cleaner
-
-  # Rails dev/test default: findings.log in the environment/session directory.
-  # A custom path bypasses session isolation; nil disables file output.
-  config.logfile = :session
-
-  # Logfile format: :text or :json (default: :text)
-  config.logfile_format = :text
-
-  # Custom callback for integrations (logging services, etc.)
-  config.notifications_callback = ->(detections, message) {
-    # detections is an array of AndOne::Detection objects
-    # message is the formatted string
-    MyLogger.warn(message)
-  }
+  # Rails development/test defaults to a session-scoped logfile.
+  # config.logfile = nil                    # disable file output
+  # config.logfile_format = :json           # default: :text
+  # config.json_logging = true              # JSON console/logger output
 end
 ```
 
-### Configuration lifecycle
+Explicit initializer settings are preserved. Configure only between scans, not while requests/jobs are running. See the [configuration reference](docs/usage.md#configuration) for callbacks, custom paths, access guards, service lifecycle, and output failure behavior.
 
-Rails defaults are applied before `config/initializers`, without overwriting explicitly assigned settings (including `logfile = nil` or `false`). Service setup and middleware registration happen after those initializers. Development/test enable scanning and a session-scoped logfile under `Rails.root/tmp/and_one/sessions`; only test raises by default. Production is disabled by default, but can be explicitly enabled.
+### Ignore accepted findings
 
-Configure before scanning. Between scans, changing `aggregate_path`, `aggregate_store`, `storage_strict`, or `ignore_file_path` rebuilds the corresponding cached service on next access. Changing `logfile` or `logfile_format` first flushes the old writer, then replaces it; a flush failure raises and rejects that configuration change. Do not reconfigure while requests/jobs are running. Other settings are read by subsequent scans/reports. Boot never resets the aggregate or truncates the logfile. See [storage and session lifecycle](docs/storage.md) for defaults, explicit resets, bounded cleanup, limits, and migration.
+Create `.and_one_ignore` in your application root:
 
-### Logfile delivery and failures
+```text
+gem:devise
+path:app/views/admin/*
+query:schema_migrations
+fingerprint:a1b2c3d4e5f6
+```
 
-New, ignore-filtered findings are flushed synchronously after each reporting scan, so they are visible before process exit. First-occurrence deduplication still applies: later occurrences update the aggregate, not the logfile. Buffered failures are retried on the next scan containing findings (even already-known findings), or explicitly with `AndOne.logfile_writer&.flush!`. Rails also attempts a final flush at exit. No timer threads are created.
+Fingerprints ignore a query shape at **all locations/connections**; `issue_id` distinguishes location-specific findings. Query rules inspect original SQL, including occurrences beyond retained samples. [Ignore rules](docs/usage.md#ignoring-n1s) · [Fingerprint compatibility and migration](docs/sql-fingerprints.md).
 
-Format/open/write failures retain pending entries. Cooperating processes use file locks; failed partial appends are rolled back when the filesystem permits. The retry buffer holds at most 1,000 unique findings; overflow rejects the new batch with a rate-limited diagnostic during reporting, preserving previously accepted entries. Newly rejected findings are not automatically redelivered because aggregate deduplication has already occurred. This is best-effort delivery, not crash durability or exactly-once delivery; shutdown, rollback failure, or buffer exhaustion can lose findings.
+### Storage and deduplication
 
-Callbacks run outside output locks and may reenter scanning. Callback and output `StandardError`s are diagnosed on stderr at most once per minute and do not fail application work or suppress configured `NPlus1Error` enforcement. `NPlus1Error` itself is always propagated, including from a nested callback scan. Callbacks are not retried. Explicit writer `record`/`flush!` calls still raise on failure. Aggregate persistence failures also default to non-disruptive, rate-limited diagnostics; `storage_strict = true` opts into propagation. See [storage policy](docs/storage.md).
-
-## Manual Scanning
-
-You can also scan specific blocks:
+The aggregate retains at most **100 issues**, evicting the least recently observed. Logs, annotations, and callbacks report only new retained issues; later occurrences update counts and costs. Evicted issues can be reported again. Every violating scan still raises when enforcement is enabled.
 
 ```ruby
-# In a test
-detections = AndOne.scan do
-  posts = Post.all
-  posts.each { |p| p.comments.to_a }
-end
-
-assert_empty detections
-
-# Pause/resume within a scan
-AndOne.scan do
-  # This is scanned
-  posts.each { |p| p.comments.to_a }
-
-  AndOne.pause do
-    # This is NOT scanned
-    legacy_code_with_known_n_plus_ones
-  end
-
-  # Scanning resumes automatically after the pause block
-end
+AndOne.aggregate.summary    # formatted retained findings
+AndOne.aggregate.detections # entries keyed by issue_id
+AndOne.aggregate.reset!     # clear aggregate only
+AndOne.reset_session!       # also flush and truncate the configured logfile
 ```
 
-Block scans release their own detector on every exit, including exceptions, `return`, `break`, and `throw`. Only normal completion analyzes and reports findings. Nested scans pass through to the block without taking ownership of the outer scan. Nested pause blocks restore the previous pause state.
+Memory storage is process-local and disappears on exit. File storage shares findings under `tmp/and_one/sessions`; the default development session persists across restarts, while independent test boots use isolated IDs. Set `AND_ONE_SESSION` before boot to select a shared session. Quiesce writers before resets. [Storage, cleanup, and upgrade notes](docs/storage.md).
 
-For manual `AndOne.scan` / `AndOne.finish` pairs, the caller must invoke `finish` when done (including on exceptional paths, typically via `ensure`). `finish` releases the detector even if analysis or reporting raises; calling it with no active scan returns `[]`. Prefer the block API when application errors should bypass reporting.
+## Capture privacy and dashboard access
 
-## How It Works
+SQL samples are **redacted before retention** by default. Each finding retains at most 5 samples × 2,048 bytes and 20 stack frames × 256 bytes, plus exact counts and cost summaries. `Detection#queries` is a sample, not the full query history.
 
-1. **Subscribe** to `sql.active_record` notifications (built into Rails)
-2. **Group** eligible reads by ordered call stack and emitting connection context
-3. **Fingerprint** SQL to detect same-shape queries with different bind values
-4. **Resolve** table names back to ActiveRecord models and associations
-5. **Suggest** a candidate preload for basic record loading or operation-specific investigation guidance
-6. **Filter** against the `.and_one_ignore` file and aggregate tracker
+Redaction is lexical, **not complete anonymization**: identifiers, filenames, and method names can remain visible. Raw mode can expose SQL literals and absolute paths; changing modes cannot revoke previously returned output or logs. Do not expose findings publicly or assume they are safe for production capture.
 
-The middleware is designed to **never interfere with error propagation**. If your app raises an exception during a request, AndOne silently stops scanning and re-raises the original exception with its backtrace completely intact.
+The dashboard defaults to direct loopback peers (`127.0.0.1`/`::1`) and sends `Cache-Control: no-store`. A local reverse proxy can make remote clients appear local. Secure the proxy or configure `dashboard_access_guard` using server-verified authentication. [Privacy and access configuration](docs/usage.md#capture-privacy-and-dashboard-access).
+
+## Capture coverage and limits
+
+- Scans capture synchronous ActiveRecord SQL in the **current fiber**. Child threads/fibers need their own scans; async-tagged SQL is excluded.
+- Request scanning ends when the application returns its response. Lazy/streaming response-body SQL is outside that scan.
+- Detection excludes cached queries and schema events. Costs describe eligible executed reads, not total request time or database-server CPU time.
+- Samples and aggregate history are bounded, but distinct groups per scan and incoming SQL size are not. Parsing work and total scan memory are not strictly bounded.
+- Block scans clean up on exceptions and nonlocal exits; nested scans reuse the outer scope. Use `AndOne.pause { ... }` to exclude known work.
+
+## Documentation
+
+- [Usage reference](docs/usage.md): output example, jobs, matchers, manual scans, configuration, privacy, and logging
+- [Capture and measured costs](docs/capture.md): execution boundaries, private signatures, metrics, and benchmarks
+- [Storage and sessions](docs/storage.md): sharing, retention, failures, resets, and migration
+- [SQL fingerprints](docs/sql-fingerprints.md): eligibility, identity, supported syntax, and limitations
+- [Compatibility](docs/compatibility.md): tested Ruby/Rails/adapters, accuracy corpus, and local test commands
+- [Marketing site](site/README.md): local preview and GitHub Pages deployment
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+[MIT](LICENSE.txt).

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -55,10 +55,11 @@ location/ignore semantics, but later occurrences do not replace retained stacks
 or metadata. No bind objects or connection objects are retained.
 
 This bounds repeated-occurrence retention, **not total scan memory**: distinct
-shapes/stacks/connections still create groups, and individual SQL strings and
-stack depth are not byte-capped. SQL parsing and stack fingerprinting still cost
-work per eligible event. Global storage retention and SQL redaction are separate
-concerns; do not treat these samples as sanitized SQL.
+shapes/stacks/connections still create groups. Retained samples are redacted by
+default and capped at 2,048 bytes each; retained stacks hold at most 20 frames of
+256 bytes each. Incoming SQL size and stack depth are not capped before parsing
+and fingerprinting, which still cost work per eligible event. Redaction is not
+complete anonymization; see [capture privacy](usage.md#capture-privacy-and-dashboard-access).
 
 Configured `ignore_queries` regexes continue excluding individual events before
 counting. Ignore-file `query:` rules instead suppress a whole repeated group if

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -98,9 +98,11 @@ high-throughput database. Atomic rename prevents partial documents; there is no
 fsync/power-loss durability guarantee. New aggregate/lock/log files use 0600;
 new session/store directories use 0700. Existing permissions are not changed.
 
-**SQL samples are still raw and may contain secrets.** Size limits and file
-permissions are not redaction or dashboard authentication; that remains #10.
-Do not expose this storage or dashboard to untrusted users.
+**SQL samples are redacted by default, but are not completely anonymous.**
+Identifiers and application filenames can remain visible; opt-in raw capture can
+retain secrets. Historical samples are sanitized when read in redacted mode,
+but old logs/backups are not revoked. Do not expose findings to untrusted users.
+See [capture privacy and dashboard access](usage.md#capture-privacy-and-dashboard-access).
 
 By default, filesystem errors, corrupt/invalid JSON, oversized documents, and
 failed writes produce a stderr diagnostic at most once per minute per Aggregate

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,473 @@
+# AndOne usage reference
+
+See the [README](../README.md) for installation and a quick start. This reference covers configuration, integrations, and operational limits.
+
+AndOne detects repeated ActiveRecord reads and suggests what to investigate; repetition alone does not prove an association N+1.
+
+## Features
+
+- **Zero configuration** — Railtie auto-setup in development and test
+- **Qualified fix suggestions** — suggests candidate `.includes()`/`.preload()` calls for basic association record loading, with separate guidance for counts and scalar queries
+- **Location hints** — shows the origin and a heuristic caller location to investigate (not the proven relation-construction site)
+- **Clean error handling** — never corrupts backtraces or interferes with exception propagation
+- **No external dependencies** — only Rails itself
+- **Auto-raises in test** — N+1s fail your test suite by default
+- **Background job support** — ActiveJob (`around_perform`) and Sidekiq server middleware, with double-scan protection
+- **Ignore file** — `.and_one_ignore` with `gem:`, `path:`, `query:`, and `fingerprint:` rules
+- **Bounded deduplication** — occurrence counts with in-memory storage by default and opt-in shared, session-scoped file storage
+- **Test matchers** — Minitest (`assert_no_n_plus_one`) and RSpec (`expect { }.not_to cause_n_plus_one`)
+- **Dev toast notifications** — in-page toast on every page that triggers an N+1, with a link to the dashboard
+- **Dev UI dashboard** — browse `/__and_one` in development; rank findings by observed SQL time, occurrences, or executed query count
+- **Rails console integration** — auto-scans in `rails console` and prints warnings inline
+- **Structured JSON logging** — JSON output mode for Datadog, Splunk, and other log aggregation services
+- **Per-environment thresholds** — different `min_n_queries` for development vs test
+- **GitHub Actions annotations** — N+1s appear as warning annotations on PR diffs
+- **`strict_loading` suggestions** — also suggests model-level prevention as an alternative
+- **Conservative association resolution** — handles unambiguous `belongs_to`, `has_one`, and `has_many`; abstains on complex or ambiguous SQL
+- **Isolated capture** — one SQL subscriber, fiber-local scans, and bounded representative query samples; verified with concurrent stress tests
+
+## Finding classification
+
+Repeated SQL is evidence, not proof of an association N+1. Findings expose `kind` and `confidence` (symbols in Ruby, strings in JSON):
+
+| Kind | Confidence | Evidence |
+|---|---|---|
+| `suspected_association_n_plus_one` | `candidate` | Varying value signatures in simple record SELECTs with qualified equality/IN predicates |
+| `duplicate_identical_read` | `observed` | Non-aggregate reads have identical lexical SQL/value signatures |
+| `repeated_aggregate` | `observed` | COUNT, SUM/AVG/MIN/MAX, or EXISTS-style projection; no record-preload advice |
+| `generic_repetition` | `unknown` | Missing/unsupported evidence, scalar or complex varying reads |
+
+Signatures use a random per-scan HMAC key and retain only one digest per group, never raw bind values. Already materialized primitive `type_casted_binds` arrays can be compared; lazy callbacks and bind objects are never evaluated. Literal SQL is compared only where lexical evidence is supported. Missing evidence on even a late occurrence makes value-based classification abstain. See [signature bounds and limitations](capture.md#classification-evidence).
+
+Variation is across the **whole value vector**, not proof of different parents or Ruby association calls. Intentional batching can still produce findings. Identical reads need not return identical results or be safe to cache. Existing thresholds, ignores, counts, fingerprints, issue IDs, `NPlus1Error`, matchers, and the legacy JSON event name remain unchanged: enforcement still applies to **all** finding kinds. Aggregate classification describes its retained representative scan, not merged evidence across requests; older/manual detections default to generic/unknown.
+
+## Recommendation limits
+
+SQL alone does not prove which Ruby association was called. Association advice uses currently loaded models and qualified equality/`IN` predicates in plain, single-table SELECTs. Both foreign keys and `belongs_to` target primary keys (including custom single-column keys) are considered. Multiple matching associations/models, through associations, polymorphic associations, joins, aliases, CTEs, composite keys, and other complex SQL may receive only non-actionable guidance. Models and reflections are not cached: late-loaded models and Rails-reloaded classes are considered on the next resolution without retaining stale misses/classes.
+
+For basic record loading, try the suggested `includes` or `preload` on the parent relation and verify equivalent scopes/results and fewer queries. Filters or AND/OR tokens do **not** establish that a JOIN is faster. COUNT receives counter-cache/grouped-count guidance: `includes` alone does not eliminate association `.count` queries; `.size` can reuse an already loaded association when loading all its records is acceptable. Existence and scalar lookups receive batching guidance rather than an invented association fix. `strict_loading` hints apply to lazy record loading, not count/existence queries.
+
+The possible fix location is a **heuristic** caller frame, not necessarily where the relation was constructed. Text, dashboard, and GitHub annotations label it accordingly; JSON retains `fix_location` and adds `fix_location_confidence: "heuristic"`. JSON suggestions include `operation`, `association_type`, and `confidence` (`candidate` or `guidance_only`); guidance-only entries may have a null association/loading strategy.
+
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+group :development, :test do
+  gem "and_one"
+end
+```
+
+That's it. AndOne automatically activates in development and test environments via a Railtie.
+
+## Ruby and ORM support
+
+AndOne requires Ruby 3.2+ and ActiveRecord/ActiveSupport/Railties 7.0+ (choose versions compatible with your Ruby). Rails applications get automatic request/job integration. Outside a Rails application, “plain Ruby” support means **ActiveRecord SQL instrumentation**, not arbitrary database clients or other ORMs such as Sequel. Railties remains a runtime dependency; RSpec is optional and only needed for `and_one/rspec`. No public RBS signatures are currently shipped.
+
+CI exercises Ruby/Rails 3.2/7.0, 3.3/7.2, and 4.0/8.1 on SQLite, plus the oldest/current boundaries on PostgreSQL 16 and MySQL 8.0. A 17-scenario labeled corpus checks recommendation accuracy, known limitations, and before/after result equivalence and physical query counts. See [the support matrix and local reproduction commands](compatibility.md).
+
+A standalone script can use:
+
+```ruby
+require "and_one"       # loads its ActiveRecord and Railtie dependencies itself
+require "sqlite3"       # install your chosen database adapter separately
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "app.sqlite3")
+# Define/load your ActiveRecord models, e.g. Post has_many :comments.
+AndOne.configure do |config|
+  config.enabled = true
+  config.raise_on_detect = false
+end
+
+detections = AndOne.scan do
+  Post.all.each { |post| post.comments.to_a }
+end
+puts "Detected #{detections.size} repeated-query patterns"
+```
+
+Standalone scans are enabled by default and do not raise unless configured. They do not install request/job hooks or Rails environment defaults until a Rails application boots. Normal scans keep bounded findings in memory by default; set `aggregate_store = :file` before the first scan for process sharing. `require "and_one"` is safe before or after loading Rails.
+
+## Capture coverage and limits
+
+Scans capture synchronous ActiveRecord SQL in the **current fiber**. Child fibers/threads do not inherit scans; start independent scans inside them if needed. Async-tagged SQL is excluded because Rails may publish worker notifications later in an unrelated consumer's scan. Synchronous `load_async` fallback is captured normally. Lazy response-body SQL is outside request scan coverage.
+
+One process-level subscriber routes events to the active context. Each repeated shape/location retains its first five SQL samples plus an exact total count: `Detection#queries` is a sample, while `Detection#count` includes all eligible occurrences. Query-ignore rules still inspect every occurrence. Retained SQL samples are capped at 2,048 bytes each and stacks at 20 frames of 256 bytes each. Distinct groups and incoming SQL size are not capped, so total scan memory and parsing work are not bounded.
+
+Findings expose `query_cost` timing summaries from monotonic SQL notifications; aggregate entries roll them up across repeated occurrences. Cache hits and async work are excluded, and historical missing costs remain unknown. These are observed costs, not estimated savings. JSON rollups are available through `AndOne::JsonFormatter.new.format_aggregate(AndOne.aggregate.detections)`.
+
+See [capture boundaries, measured costs, retention, and benchmark commands](capture.md) for details.
+
+## What You'll See
+
+When an N+1 is detected, you get output like:
+
+```
+──────────────────────────────────────────────────────────────────────────
+ 🏀 And One! 1 repeated-query finding detected
+──────────────────────────────────────────────────────────────────────────
+
+  1) 9x repeated query on `comments`
+     suspected association N+1 (candidate)
+     fingerprint: a1b2c3d4e5f6
+
+  Query:
+    SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?
+
+  Origin (where the repeated query is triggered):
+  → app/views/posts/index.html.erb:5
+
+  Possible fix location (heuristic; inspect the caller):
+  ⇒ app/controllers/posts_controller.rb:8
+
+  Call stack:
+    app/views/posts/index.html.erb:5
+    app/controllers/posts_controller.rb:8
+
+  💡 Suggestion:
+    If this is Post#comments record loading, try `.includes(:comments)` or `.preload(:comments)` on the parent query; verify scopes and results.
+
+  To ignore, add to .and_one_ignore:
+    fingerprint:a1b2c3d4e5f6
+
+──────────────────────────────────────────────────────────────────────────
+```
+
+## Background Jobs
+
+### ActiveJob (any backend)
+
+Automatically hooked via `around_perform`. Works with **every** ActiveJob backend:
+Sidekiq, GoodJob, SolidQueue, Delayed Job, Resque, and anything else that uses ActiveJob.
+
+No configuration needed — the Railtie handles it.
+
+### Sidekiq (direct usage)
+
+For jobs that use Sidekiq directly (bypassing ActiveJob), AndOne installs a server middleware automatically when Sidekiq is detected.
+
+If you need manual installation:
+
+```ruby
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add AndOne::SidekiqMiddleware
+  end
+end
+```
+
+When both hooks are active (an ActiveJob job running through Sidekiq), the inner hook reuses the outer scan — no double-scanning.
+
+## Ignoring N+1s
+
+### The `.and_one_ignore` file
+
+Create a `.and_one_ignore` file in your project root to permanently silence known N+1s. Supports four rule types:
+
+```bash
+# Ignore N+1s originating from a specific gem
+# (matches against raw backtrace paths, e.g. /gems/devise-4.9.0/)
+gem:devise
+gem:administrate
+
+# Ignore N+1s whose call stack matches a path pattern (supports * globs)
+path:app/views/admin/*
+path:lib/legacy/**
+
+# Ignore N+1s matching a SQL pattern
+query:schema_migrations
+query:pg_catalog
+
+# Ignore a query shape at all locations by its fingerprint (shown in output)
+fingerprint:a1b2c3d4e5f6
+```
+
+This is especially useful for **N+1s coming from gems** where you can't add `.includes()` to the source. Instead of littering your code with `AndOne.pause` blocks, add a `gem:` rule.
+
+### When to use each rule type
+
+| Rule | Use when... |
+|---|---|
+| `gem:devise` | A gem you depend on has an N+1 you can't fix |
+| `path:app/views/admin/*` | An area of your app has known N+1s you've accepted |
+| `query:some_table` | A specific query pattern should always be ignored |
+| `fingerprint:abc123` | You want to silence a query shape at all locations/connections |
+
+## Deduplication
+
+In development, the same N+1 can fire on every request, flooding your logs. AndOne automatically deduplicates — each unique issue (query shape + application origin + connection context) is reported only once while retained in the aggregate (per process by default, or across cooperating processes with file storage). Subsequent occurrences at that location are silently counted; the same SQL shape at a different location remains visible as a separate issue.
+
+Deduplication applies to logs, GitHub annotations, logfile output, and `notifications_callback` (which receives only newly observed findings). Scan results still contain every non-ignored finding in that scan. When `raise_on_detect` is enabled, **every violating scan raises**, even if the pattern was already reported by another scan. Test matchers do not report or consume first-occurrence deduplication.
+
+You can check the session summary at any time:
+
+```ruby
+AndOne.aggregate.summary    # formatted string of all unique N+1s
+AndOne.aggregate.size       # number of unique issues
+AndOne.aggregate.detections # { issue_id => Entry }; entry.detection.fingerprint is the broad ignore key
+AndOne.aggregate.reset!     # clear and start fresh
+```
+
+Output includes a location-aware `issue_id` alongside the unchanged broad `fingerprint` ignore key. Stored entries retain both identities. Old shape-keyed entries are migrated using their retained location; reset once on upgrade to avoid duplicate historical entries without connection metadata. See [identity and eligibility limits](sql-fingerprints.md#query-shape-versus-issue-identity).
+
+SQL normalization version 2 can change detection fingerprints. When upgrading, reset stale aggregate data and regenerate affected `fingerprint:` ignore entries. See [SQL fingerprints](sql-fingerprints.md) for supported syntax, dialect limitations, and migration steps.
+
+## Development UI
+
+### In-page toast notifications
+
+When an N+1 is detected during a request, AndOne injects a small toast notification into the top-right corner of the page. The toast shows which tables were affected and links to the full dashboard for details.
+
+This is enabled by default in development — no configuration needed. The toast auto-dismisses after 8 seconds, but hovering over it keeps it open.
+
+To change the position or disable it:
+
+```ruby
+# config/initializers/and_one.rb
+AndOne.dev_toast_position = :bottom_right  # :top_right (default), :top_left, :bottom_right, :bottom_left
+AndOne.dev_toast = false                   # disable entirely
+```
+
+The toast only transforms complete `text/html` responses with status 200 and a Rack `to_ary` body (including ordinary Rails renders). HEAD, API, redirect, error, encoded/compressed, streaming, file/download, and partial responses are left untouched. Place AndOne inside compression middleware to inject before compression. Transformed responses lose Content-Length and validators/digests; untouched content keeps its metadata. Rack bodies own cleanup in `to_ary`, including on conversion errors; AndOne does not enumerate arbitrary bodies or close converted bodies a second time.
+
+With a Content-Security-Policy header (including report-only) or CSP meta tag, the toast becomes an unstyled, script-free native `<details>` notice with a dashboard link. It does not auto-dismiss or use the position setting, and never requires `unsafe-inline` or changes your policy.
+
+**SQL coverage:** scanning ends when the application returns its Rack response, before lazy body enumeration. Queries executed by streaming/lazy bodies are not captured by this middleware; use an explicit scan within that workload if needed.
+
+### Dashboard
+
+Browse `/__and_one` in development for retained findings (up to 100 issues, process-local by default). The dashboard shows classification, observed query costs, SQL samples, origin, heuristic fix location, and operation-specific advice. With file storage, the default development session survives server restarts until reset or eviction. Access defaults to loopback peers (`127.0.0.1` or `::1`); missing/remote peer addresses receive 403. See [capture privacy and dashboard access](#capture-privacy-and-dashboard-access) for shared-development setups.
+
+Both features work together: the toast gives you immediate feedback on the page you're looking at, and the dashboard link takes you to the full picture.
+
+## Test Matchers
+
+### Minitest
+
+```ruby
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  include AndOne::MinitestHelper
+
+  test "index does not cause N+1 queries" do
+    assert_no_n_plus_one do
+      get posts_path
+    end
+  end
+
+  test "known N+1 is documented" do
+    detections = assert_n_plus_one do
+      get legacy_report_path
+    end
+    assert_equal "comments", detections.first.table_name
+  end
+end
+```
+
+### RSpec
+
+```ruby
+# In spec_helper.rb or rails_helper.rb
+require "and_one/rspec" # loads RSpec core and registers the helper, in either require order
+
+# Then in your specs
+RSpec.describe "Posts" do
+  it "loads posts efficiently" do
+    expect {
+      Post.includes(:comments).each { |p| p.comments.to_a }
+    }.not_to cause_n_plus_one
+  end
+
+  it "has a known N+1" do
+    expect {
+      Post.all.each { |p| p.comments.to_a }
+    }.to cause_n_plus_one
+  end
+end
+```
+
+N+1 matchers capture a non-reporting scan: they never change global configuration, invoke callbacks, write findings, or raise `NPlus1Error`. Other concurrent scans retain their configured reporting and enforcement. Ignores and `enabled = false` still apply (disabled matchers execute the block but see no detections).
+
+Starting an N+1 matcher inside an already active scan raises `ArgumentError` **before executing its block**. Put the matcher around the request/job or scan instead; ordinary nested request/job scans still pass through to the matcher's scope. Both successful Minitest helpers count one assertion.
+
+### Physical query budgets and input growth
+
+These explicit measurements count database work independently of repeated-shape detection:
+
+```ruby
+# Create fixtures and warm schema/connection caches BEFORE these scopes.
+# Workloads must build fresh relations/records, not reuse loaded associations.
+small = -> { Post.limit(2).preload(:comments).each { |p| p.comments.to_a } }
+large = -> { Post.limit(20).preload(:comments).each { |p| p.comments.to_a } }
+
+# Minitest (include AndOne::MinitestHelper)
+result = assert_query_budget(max: 2, &large)
+result.count         # executed query count
+result.cached_count  # cache hits, excluded from the budget
+result.locations     # up to five query call sites, no SQL/bind values
+result = assert_query_growth(small: small, large: large, max_growth: 0)
+result.growth        # large.count - small.count
+
+# RSpec (require "and_one/rspec")
+expect(&large).to stay_within_query_budget(2)
+expect(small: small, large: large).to stay_within_query_growth(0)
+```
+
+Limits are non-negative integers and inclusive. Growth measures the **absolute increase** in query count, not a ratio or timing: a bound of zero requires constant or decreasing counts. Each supplied workload runs exactly once, small before large; the library never creates fixtures, warms up, clears caches, or silently reruns your block. Choose genuinely different input sizes and prepare sufficient data yourself. Setup performed inside a workload is counted.
+
+Counts include non-cached `sql.active_record` events, including reads, writes, and transaction statements, but exclude `SCHEMA` events and empty SQL. Cache hits are counted separately. Existing cache state is preserved: for cold-query regression tests wrap the assertions in `ActiveRecord::Base.uncached`; for warm-cache tests warm up explicitly outside measurement. These are notification counts, not network round trips (e.g. a multi-statement event counts once).
+
+Captures are fiber-local; nested captures are inclusive for the parent and independent for the child. Exceptions and nonlocal exits restore the parent scope. Child fibers, threads, and asynchronous queries are not included. Unlike N+1 matchers, these explicit counts remain active when AndOne is disabled/paused and do not apply ignores or detection thresholds. They neither start an N+1 scan nor change reporting settings: existing or nested application scans retain their normal enforcement and can still raise `NPlus1Error`. Failures show small/large counts and bounded query locations without retaining SQL or bind values. Query budgets complement, rather than prove the absence of, N+1 behavior.
+
+## Behavior by Environment
+
+- **Development**: Logs N+1 warnings to Rails logger and stderr
+- **Test**: Raises `AndOne::NPlus1Error` so N+1s fail your test suite
+- **Production**: Disabled by default if loaded; the recommended Gemfile group excludes it
+
+## Capture privacy and dashboard access
+
+The default `AndOne.capture_mode = :redacted` replaces SQL string/numeric/boolean literals, bind placeholders, comments (including hints), and opaque/unterminated tokens with `?` **before retaining samples**. Bind values are never retained; already materialized primitive arrays may be hashed for classification. Lazy bind callbacks are never evaluated. This affects returned detections, callbacks, exceptions, text/JSON output, logs, aggregate storage, and the dashboard—not SQL execution. Fingerprints and query-ignore matching use original SQL before redaction, including occurrences beyond the sample limit. Caller/path/gem ignores inspect the original stack before capture limits.
+
+Each detection retains at most **5 SQL samples × 2,048 bytes** and **20 frames × 256 bytes** in either mode. Frames prioritize application code while preserving stack order. Default frames remove absolute application prefixes; external paths become portable suffixes/filenames. `raw_caller_strings` now means policy-limited strings before optional backtrace cleaning; `caller_locations` contains bounded snapshots with `path`, `absolute_path`, `lineno`, and `to_s` accessors.
+
+Redaction is lexical, not complete anonymization: schema/table/column identifiers and application filenames/method names remain visible. Adapter-specific quoting matters; SQLite/unknown-adapter ambiguous double-quoted values are conservatively masked, which can hide unqualified column names too. Backslashes in quoted tokens conservatively mask the rest of the sample because session-dependent escaping rules can be ambiguous. Avoid embedding secrets in identifiers or using unsupported vendor literal syntax. Do not expose findings publicly or enable production capture on the assumption that redaction removes all sensitive information.
+
+For temporary local debugging only, opt in explicitly **before scanning**:
+
+```ruby
+AndOne.capture_mode = :raw # WARNING: SQL literals and absolute paths can contain credentials/PII
+```
+
+Raw mode remains bounded and does not capture binds. Changing modes cannot revoke already returned detections, callbacks, or written logs. Existing aggregate samples are sanitized when read under redacted mode; old logs/backups must be removed separately. Newly created aggregate, lock, and log files use mode `0600` (aggregate directories use `0700`); existing files' permissions are not automatically changed.
+
+The dashboard returns `Cache-Control: no-store`. It trusts only the direct Rack `REMOTE_ADDR`, not forwarding headers. A local reverse proxy can make remote clients appear local: secure the proxy or supply an explicit guard. For shared development, integrate with trusted authentication middleware **before** DevUI:
+
+```ruby
+AndOne.dashboard_access_guard = ->(env) { env["my_app.authenticated_developer"] == true }
+```
+
+A configured callable replaces the loopback check; false/nil or an exception denies access. Only use server-verified identity, not an arbitrary client header. This is an access hook, not an authentication framework.
+
+## Configuration
+
+AndOne works out of the box, but you can customize:
+
+```ruby
+# config/initializers/and_one.rb
+AndOne.configure do |config|
+  # Raise on detection (default: true in test, false in development)
+  config.raise_on_detect = false
+
+  # Minimum repeated queries to trigger (default: 2)
+  config.min_n_queries = 3
+
+  # In-page toast notifications (default: true in development)
+  config.dev_toast = true
+
+  # Toast position (default: :top_right)
+  # Options: :top_right, :top_left, :bottom_right, :bottom_left
+  config.dev_toast_position = :top_right
+
+  # Opt in to process sharing (default: bounded in-memory storage)
+  config.aggregate_store = :file
+
+  # Optional exact custom directory; also opts into file storage.
+  # Custom paths bypass automatic environment/session isolation.
+  # config.aggregate_path = Rails.root.join("tmp", "my_findings").to_s
+
+  # Raise storage errors instead of diagnosing them (default: false)
+  config.storage_strict = false
+
+  # Path to ignore file (default: Rails.root/.and_one_ignore)
+  config.ignore_file_path = Rails.root.join(".and_one_ignore").to_s
+
+  # Allow specific patterns (won't flag these call stacks)
+  config.allow_stack_paths = [
+    /admin_controller/,
+    /some_legacy_code/
+  ]
+
+  # Ignore specific query patterns
+  config.ignore_queries = [
+    /pg_catalog/,
+    /schema_migrations/
+  ]
+
+  # Custom backtrace cleaner
+  config.backtrace_cleaner = Rails.backtrace_cleaner
+
+  # Rails dev/test default: findings.log in the environment/session directory.
+  # A custom path bypasses session isolation; nil disables file output.
+  config.logfile = :session
+
+  # Logfile format: :text or :json (default: :text)
+  config.logfile_format = :text
+
+  # Custom callback for integrations (logging services, etc.)
+  config.notifications_callback = ->(detections, message) {
+    # detections is an array of AndOne::Detection objects
+    # message is the formatted string
+    MyLogger.warn(message)
+  }
+end
+```
+
+### Configuration lifecycle
+
+Rails defaults are applied before `config/initializers`, without overwriting explicitly assigned settings (including `logfile = nil` or `false`). Service setup and middleware registration happen after those initializers. Development/test enable scanning and a session-scoped logfile under `Rails.root/tmp/and_one/sessions`; only test raises by default. Production is disabled by default, but can be explicitly enabled.
+
+Configure before scanning. Between scans, changing `aggregate_path`, `aggregate_store`, `storage_strict`, or `ignore_file_path` rebuilds the corresponding cached service on next access. Changing `logfile` or `logfile_format` first flushes the old writer, then replaces it; a flush failure raises and rejects that configuration change. Do not reconfigure while requests/jobs are running. Other settings are read by subsequent scans/reports. Boot never resets the aggregate or truncates the logfile. See [storage and session lifecycle](storage.md) for defaults, explicit resets, bounded cleanup, limits, and migration.
+
+### Logfile delivery and failures
+
+New, ignore-filtered findings are flushed synchronously after each reporting scan, so they are visible before process exit. First-occurrence deduplication still applies: later occurrences update the aggregate, not the logfile. Buffered failures are retried on the next scan containing findings (even already-known findings), or explicitly with `AndOne.logfile_writer&.flush!`. Rails also attempts a final flush at exit. No timer threads are created.
+
+Format/open/write failures retain pending entries. Cooperating processes use file locks; failed partial appends are rolled back when the filesystem permits. The retry buffer holds at most 1,000 unique findings; overflow rejects the new batch with a rate-limited diagnostic during reporting, preserving previously accepted entries. Newly rejected findings are not automatically redelivered because aggregate deduplication has already occurred. This is best-effort delivery, not crash durability or exactly-once delivery; shutdown, rollback failure, or buffer exhaustion can lose findings.
+
+Callbacks run outside output locks and may reenter scanning. Callback and output `StandardError`s are diagnosed on stderr at most once per minute and do not fail application work or suppress configured `NPlus1Error` enforcement. `NPlus1Error` itself is always propagated, including from a nested callback scan. Callbacks are not retried. Explicit writer `record`/`flush!` calls still raise on failure. Aggregate persistence failures also default to non-disruptive, rate-limited diagnostics; `storage_strict = true` opts into propagation. See [storage policy](storage.md).
+
+## Manual Scanning
+
+You can also scan specific blocks:
+
+```ruby
+# When raise_on_detect is false (use test matchers for assertions)
+detections = AndOne.scan do
+  posts = Post.all
+  posts.each { |p| p.comments.to_a }
+end
+
+puts "Detected #{detections.size} repeated-query patterns"
+
+# Pause/resume within a scan
+AndOne.scan do
+  # This is scanned
+  posts.each { |p| p.comments.to_a }
+
+  AndOne.pause do
+    # This is NOT scanned
+    legacy_code_with_known_n_plus_ones
+  end
+
+  # Scanning resumes automatically after the pause block
+end
+```
+
+Block scans release their own detector on every exit, including exceptions, `return`, `break`, and `throw`. Only normal completion analyzes and reports findings. Nested scans pass through to the block without taking ownership of the outer scan. Nested pause blocks restore the previous pause state.
+
+For manual `AndOne.scan` / `AndOne.finish` pairs, the caller must invoke `finish` when done (including on exceptional paths, typically via `ensure`). `finish` releases the detector even if analysis or reporting raises; calling it with no active scan returns `[]`. Prefer the block API when application errors should bypass reporting.
+
+## How It Works
+
+1. **Subscribe** to `sql.active_record` notifications (built into Rails)
+2. **Group** eligible reads by ordered call stack and emitting connection context
+3. **Fingerprint** SQL to detect repeated shapes, then classify using bounded private value signatures when supported
+4. **Resolve** table names back to ActiveRecord models and associations
+5. **Suggest** a candidate preload for basic record loading or operation-specific investigation guidance
+6. **Filter** against the `.and_one_ignore` file and aggregate tracker
+
+The middleware is designed to **never interfere with error propagation**. If your app raises an exception during a request, AndOne silently stops scanning and re-raises the original exception with its backtrace completely intact.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,42 @@
+# AndOne marketing site
+
+Dependency-free HTML, CSS, and a progressively enhanced copy button. No build step,
+external fonts, analytics, or third-party scripts. The finding card is an illustrative
+example, not a live dashboard or benchmark.
+
+## Preview locally
+
+From the repository root:
+
+```sh
+python3 -m http.server 8000 --directory site
+```
+
+Open http://localhost:8000. To verify GitHub Pages project-path behavior, serve the
+repository root instead and visit http://localhost:8000/site/; all asset links are relative.
+
+## Deploy
+
+1. In the repository's **Settings → Pages → Build and deployment**, select
+   **GitHub Actions** as the source.
+2. Merge the site and `.github/workflows/pages.yml` into `main`.
+3. The **Deploy marketing site** workflow publishes `site/` on changes to the site
+   or workflow. You can also run it manually from the Actions tab on `main`.
+
+Default URL: https://keiththomps.github.io/and_one/
+
+For a custom domain, configure it in Settings → Pages and set the required DNS
+records. The site makes no assumptions about the hostname or project prefix.
+
+## Editing and checks
+
+- `index.html`: content, metadata, examples, and documentation links.
+- `assets/style.css`: responsive layout, local system fonts, and reduced-motion support.
+- `assets/site.js`: copy-to-clipboard enhancement with manual-selection fallback.
+- `assets/icon.svg`: basketball mark and favicon.
+
+Before publishing, check narrow/mobile and desktop layouts, keyboard navigation,
+FAQ disclosure controls, and copy success/failure. Core content and navigation
+must work with JavaScript disabled. Keep feature claims consistent with the Ruby
+implementation and linked technical docs; never present illustrative timings as
+performance guarantees.

--- a/site/assets/icon.svg
+++ b/site/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle cx="24" cy="24" r="22" fill="#ef6238" stroke="#20231e" stroke-width="2.5"/>
+  <g fill="none" stroke="#20231e" stroke-width="2" transform="rotate(-25 24 24)">
+    <path d="M24 2v44M2 24h44M12 6c16 10 16 26 0 36M36 6c-16 10-16 26 0 36"/>
+  </g>
+</svg>

--- a/site/assets/site.js
+++ b/site/assets/site.js
@@ -1,0 +1,22 @@
+"use strict";
+
+// Everything else works without JavaScript. Reveal copy controls only when ready.
+for (const button of document.querySelectorAll("[data-copy]")) {
+  button.hidden = false;
+  button.addEventListener("click", async () => {
+    const snippet = document.getElementById(button.dataset.copy);
+    const status = document.querySelector(".copy-status");
+    try {
+      await navigator.clipboard.writeText(snippet.textContent);
+      status.textContent = "Copied. Add it to your Gemfile, then run bundle install.";
+    } catch {
+      // Local HTTP or denied clipboard permissions: select for manual copying.
+      const range = document.createRange();
+      range.selectNodeContents(snippet);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      status.textContent = "Snippet selected. Press Ctrl+C (or ⌘C) to copy.";
+    }
+  });
+}

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1,0 +1,266 @@
+:root {
+  color-scheme: light;
+  --paper: #f4f2eb;
+  --ink: #20231e;
+  --muted: #62665b;
+  --orange: #c6401b;
+  --bright: #ef6238;
+  --line: #d9dad0;
+  --mono: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 30px; }
+body { margin: 0; background: var(--paper); color: var(--ink); font-family: var(--sans); -webkit-font-smoothing: antialiased; }
+::selection { background: #f8b897; color: var(--ink); }
+a { color: inherit; text-decoration: none; }
+button { font: inherit; }
+button, a, summary { -webkit-tap-highlight-color: transparent; }
+a:focus-visible, button:focus-visible, summary:focus-visible { outline: 3px solid var(--orange); outline-offset: 5px; }
+img, svg { display: block; }
+p { line-height: 1.65; }
+pre { margin: 0; overflow-x: auto; }
+code { font-family: var(--mono); }
+.wrap { max-width: 1260px; width: calc(100% - 96px); margin-inline: auto; }
+.skip-link { position: absolute; top: -100px; left: 20px; padding: 14px 24px; background: var(--ink); color: white; z-index: 10; }
+.skip-link:focus { top: 12px; }
+.site-header { height: 108px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--line); }
+.brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 850; font-size: 27px; letter-spacing: -1.4px; }
+.brand-dot { color: var(--orange); margin-left: -9px; }
+.site-header nav { display: flex; align-items: center; gap: 34px; font-size: 14px; font-weight: 600; }
+.site-header nav a:hover, .site-footer nav a:hover { color: var(--orange); }
+.nav-github { border: 1px solid #bfc2b6; padding: 12px 19px; border-radius: 5px; }
+.nav-github span { padding-left: 14px; }
+.hero { display: grid; grid-template-columns: 1.05fr 1fr; gap: 62px; align-items: center; padding-block: 100px 104px; }
+.eyebrow { display: flex; align-items: center; gap: 9px; font-family: var(--mono); font-weight: 600; font-size: 11px; line-height: 1.5; letter-spacing: 1.4px; text-transform: uppercase; margin: 0 0 24px; }
+.status-dot { display: inline-block; flex: 0 0 auto; width: 7px; height: 7px; background: var(--orange); border-radius: 50%; }
+h1 { font-size: clamp(58px, 6.4vw, 88px); line-height: 1.01; letter-spacing: -5px; font-weight: 850; margin: 0 0 34px; }
+.accent-word { color: var(--orange); position: relative; display: inline-block; }
+.accent-word svg { position: absolute; bottom: -15px; left: -3%; width: 106%; height: 22px; stroke: var(--orange); fill: none; stroke-width: 3; stroke-linecap: round; }
+.hero-description { font-size: 21px; line-height: 1.5; letter-spacing: -.5px; margin: 0 0 15px; }
+.hero-detail { color: var(--muted); font-size: 16px; max-width: 440px; margin: 0; }
+.hero-actions { display: flex; align-items: center; gap: 26px; margin-top: 31px; }
+.button { display: inline-flex; align-items: center; justify-content: center; gap: 28px; padding: 17px 22px; border-radius: 5px; font-size: 14px; font-weight: 700; transition: transform .2s, background .2s; }
+.button:hover { transform: translateY(-2px); }
+.button-primary { background: var(--orange); color: white; box-shadow: 0 3px 0 #a03013; }
+.button-primary:hover { background: #ad3515; }
+.button span { font-size: 20px; line-height: 1; }
+.text-link { display: inline-flex; gap: 17px; align-items: center; font-size: 13px; font-weight: 700; }
+.text-link:hover { text-decoration: underline; text-underline-offset: 5px; }
+.hero-note { font-family: var(--mono); font-size: 10px; color: var(--muted); margin-top: 20px; }
+.hero-visual { position: relative; min-width: 0; padding-top: 8px; }
+.court { position: absolute; inset: -31px -21px 15px 28px; border: 1px solid #b8c0aa; border-radius: 5px; overflow: hidden; transform: rotate(5deg); opacity: .7; background: #e4e8dc; }
+.court::before { content: ""; position: absolute; inset: 17px; border: 1px solid #b8c0aa; }
+.court::after { content: ""; position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: #b8c0aa; }
+.court-circle { position: absolute; width: 150px; height: 150px; top: calc(50% - 75px); left: calc(50% - 75px); border: 1px solid #b8c0aa; border-radius: 50%; }
+.court-key { position: absolute; top: 17px; left: 30%; right: 30%; height: 100px; border: 1px solid #b8c0aa; }
+.finding-window { position: relative; background: #20251f; color: #f0f1e8; border: 1px solid #41463d; border-radius: 9px; box-shadow: 0 24px 50px #20231e26, 0 3px 7px #20231e16; transform: rotate(-1deg); }
+.window-bar { padding: 17px 15px; display: flex; align-items: center; gap: 13px; border-bottom: 1px solid #3c4136; font-family: var(--mono); font-size: 9px; color: #b5beab; }
+.window-dots { display: flex; gap: 5px; }
+.window-dots i { height: 7px; width: 7px; border-radius: 50%; background: #68705e; }
+.window-dots i:first-child { background: var(--bright); }
+.live-label { margin-left: auto; font-size: 8px; letter-spacing: 1px; color: #bed394; }
+.finding-body { padding: 25px 25px 20px; }
+.finding-heading { display: flex; align-items: center; gap: 11px; }
+.finding-heading strong { display: block; font-size: 24px; letter-spacing: -.7px; }
+.finding-heading div > span { display: block; font-size: 11px; margin-top: 3px; color: #c4cbbc; }
+.finding-count { margin-left: auto; font-size: 40px; font-weight: 700; letter-spacing: -3px; color: #f9875f; }
+.finding-label { font-family: var(--mono); font-size: 8px; letter-spacing: .65px; margin: 23px 0 17px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; color: #f8a783; }
+.finding-label span { border: 1px solid #68614e; color: #dfcc9b; padding: 4px 6px; border-radius: 3px; font-size: 7px; }
+.query-code { border: 1px solid #3a4034; border-radius: 4px; background: #191e18; padding: 18px 15px; font-size: 12px; line-height: 1.9; }
+.syntax-purple { color: #d3b2e2; }
+.syntax-yellow { color: #d3dda7; }
+.syntax-orange { color: #ffa47c; }
+.syntax-muted { color: #b4c1a7; }
+.query-metrics { display: grid; grid-template-columns: 1fr 1fr; border-block: 1px solid #3c4136; margin: 21px 0; padding: 15px 0; }
+.query-metrics > div + div { border-left: 1px solid #3c4136; padding-left: 25px; }
+.query-metrics strong { display: block; font-size: 27px; font-weight: 500; letter-spacing: -.7px; }
+.query-metrics strong span { font-size: 13px; margin-left: 3px; color: #bbc4af; }
+.query-metrics div > span { display: block; margin-top: 4px; font-size: 10px; color: #bac4af; }
+.origin { display: flex; flex-direction: column; gap: 8px; }
+.origin > span { font-family: var(--mono); font-size: 8px; letter-spacing: 1px; color: #bbc4af; }
+.origin code { font-size: 10px; overflow-wrap: anywhere; }
+.suggestion { display: flex; gap: 12px; margin-top: 20px; padding: 13px; background: #30392b; border: 1px solid #45523b; border-radius: 4px; }
+.suggestion-arrow { font-size: 25px; color: #c1d5a2; }
+.suggestion p { font-size: 11px; line-height: 1.8; color: #d4ddc8; margin: 0; }
+.suggestion code { color: #e3eccf; font-size: 10px; }
+.window-footer { display: flex; gap: 8px; align-items: center; padding: 12px 25px; border-top: 1px solid #3c4136; font-family: var(--mono); font-size: 8px; color: #b9c4aa; }
+.window-footer .status-dot { width: 5px; height: 5px; background: #b9ce95; }
+.visual-caption { position: relative; text-align: right; margin: 24px 5px 0 0; font-size: 12px; color: var(--muted); font-style: italic; }
+.visual-caption span { margin-right: 10px; font-size: 25px; color: var(--orange); }
+.compat-strip { border-block: 1px solid var(--line); }
+.compat-inner { display: flex; align-items: center; gap: 30px; padding-block: 23px; }
+.compat-inner .eyebrow { margin: 0; font-size: 9px; color: var(--muted); }
+.compat-inner p { margin: 0; font-size: 12px; font-weight: 600; }
+.compat-inner p span { color: #868c7e; margin-inline: 12px; font-weight: 400; }
+.compat-inner a { margin-left: auto; color: var(--muted); font-size: 10px; text-decoration: underline; text-underline-offset: 4px; }
+.section { padding-block: 100px; }
+h2 { font-size: clamp(36px, 4vw, 52px); line-height: 1.09; letter-spacing: -2px; margin: 0; font-weight: 750; }
+.section-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 40px; margin-bottom: 45px; }
+.section-heading > p { max-width: 315px; color: var(--muted); font-size: 14px; margin-bottom: 3px; }
+.feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+.feature-card { padding: 30px; background: #f8f7f1; }
+.feature-card + .feature-card { border-left: 1px solid var(--line); }
+.feature-top { display: flex; justify-content: space-between; align-items: center; margin-bottom: 45px; }
+.step { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+.feature-top svg { width: 37px; height: 37px; stroke: var(--orange); stroke-width: 1.5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+h3 { font-size: 21px; letter-spacing: -.6px; margin: 0 0 14px; }
+.feature-card p { font-size: 14px; color: var(--muted); margin: 0 0 28px; }
+.feature-tag { font-family: var(--mono); font-size: 9px; text-transform: uppercase; letter-spacing: .7px; color: var(--orange); }
+.test-section { background: #e7eadd; border-block: 1px solid #d5dac7; padding-block: 84px; }
+.test-layout { display: grid; grid-template-columns: .9fr 1.1fr; gap: 80px; align-items: center; }
+.test-copy > p:not(.eyebrow) { color: #565f4b; font-size: 15px; max-width: 350px; margin-top: 22px; }
+.check-list { list-style: none; padding: 0; margin: 25px 0 29px; }
+.check-list li { position: relative; padding-left: 24px; margin-block: 13px; font-size: 12px; }
+.check-list li::before { content: "↗"; position: absolute; left: 0; color: #697954; }
+.test-code { min-width: 0; background: #20251f; color: #f0f1e8; border: 1px solid #41463d; border-radius: 7px; box-shadow: 8px 8px 0 #cbd2bc; }
+.code-title { padding: 18px 22px; border-bottom: 1px solid #3c4136; font-family: var(--mono); font-size: 10px; color: #c4cdb9; display: flex; align-items: center; gap: 9px; }
+.code-title > span:last-child { margin-left: auto; color: #ffa47c; font-size: 9px; }
+.file-icon { font-size: 16px; }
+.test-code pre { padding: 26px 22px; font-size: 11px; line-height: 2.1; }
+.code-footnote { padding: 15px 22px; font-size: 10px; color: #bdc9b0; border-top: 1px solid #3c4136; }
+.code-footnote span { margin-right: 5px; }
+.principles { display: grid; grid-template-columns: 1fr 1.1fr; gap: 110px; }
+.principles-intro > p:not(.eyebrow) { max-width: 330px; color: var(--muted); font-size: 15px; margin-block: 23px 27px; }
+.principle-list article { display: flex; gap: 25px; padding-block: 25px; border-bottom: 1px solid var(--line); }
+.principle-list article:first-child { padding-top: 0; }
+.principle-list article > span { color: var(--orange); font-size: 24px; width: 24px; flex: 0 0 auto; }
+.principle-list h3 { font-size: 18px; margin-bottom: 8px; }
+.principle-list p { font-size: 13px; color: var(--muted); margin: 0; }
+.install-section { background: #ef6238; border-radius: 8px; display: grid; grid-template-columns: 1.2fr 1fr; overflow: hidden; }
+.install-content { padding: 55px 0 55px 55px; position: relative; z-index: 1; }
+.install-content .eyebrow { margin-bottom: 21px; }
+.install-content h2 { font-size: clamp(32px, 3.5vw, 46px); }
+.install-content > p:not(.eyebrow, .copy-status) { font-size: 14px; max-width: 390px; margin-block: 22px; }
+.install-content > p code { font-size: 12px; }
+.install-code { background: #fff9ee; border: 1px solid #a73b1c; border-radius: 5px; max-width: 435px; }
+.install-code-header { display: flex; justify-content: space-between; align-items: center; padding: 10px 17px; border-bottom: 1px solid #e7d6c3; font-family: var(--mono); font-size: 10px; min-height: 46px; }
+.copy-button { border: 1px solid #d2c3b0; background: transparent; border-radius: 3px; color: var(--ink); font-size: 10px; padding: 6px 9px; cursor: pointer; }
+.copy-button:hover { background: #f2e9da; }
+.copy-button span { margin-left: 8px; }
+.install-code pre { padding: 20px 17px; font-size: 13px; line-height: 1.8; }
+.copy-status { font-size: 11px; min-height: 18px; margin: 5px 0; }
+.install-notes { display: flex; flex-wrap: wrap; gap: 18px; margin: 5px 0 28px; font-size: 9px; }
+.install-notes strong { display: block; font-size: 10px; margin-bottom: 5px; }
+.button-dark { background: var(--ink); color: #fff9ee; }
+.button-dark:hover { background: #343a2c; }
+.install-art { position: relative; min-width: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; overflow: hidden; }
+.install-art > span { position: relative; z-index: 1; font-size: clamp(90px, 12vw, 170px); line-height: .83; font-weight: 900; letter-spacing: -10px; transform: rotate(-9deg); }
+.install-art > p { position: relative; z-index: 1; font-family: var(--mono); font-size: 9px; font-weight: 600; letter-spacing: 1.8px; margin: 40px 0 0; transform: rotate(-9deg); }
+.large-ball { position: absolute; width: 425px; height: 425px; border: 1px solid #9d3c20; border-radius: 50%; transform: rotate(-25deg); opacity: .45; }
+.large-ball::before, .large-ball::after { content: ""; position: absolute; border: 1px solid #9d3c20; border-radius: 50%; }
+.large-ball::before { inset: 0 105px; }
+.large-ball::after { inset: 105px 0; }
+.large-ball div { height: 100%; width: 1px; background: #9d3c20; margin-inline: auto; }
+.large-ball div::after { content: ""; position: absolute; height: 1px; width: 100%; background: #9d3c20; top: 50%; left: 0; }
+.faq { padding-block: 100px; display: grid; grid-template-columns: .8fr 1.2fr; gap: 70px; }
+.faq h2 { font-size: 37px; }
+.faq details { border-bottom: 1px solid var(--line); }
+.faq details:first-child { border-top: 1px solid var(--line); }
+.faq summary { display: flex; justify-content: space-between; gap: 20px; padding-block: 21px; cursor: pointer; list-style: none; font-size: 14px; font-weight: 600; }
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary span { color: var(--orange); font-size: 20px; font-weight: 400; line-height: 1; }
+.faq details[open] summary span { transform: rotate(45deg); }
+.faq details p { font-size: 13px; color: var(--muted); margin: 0 25px 22px 0; }
+.faq details a { text-decoration: underline; text-underline-offset: 3px; color: var(--ink); }
+.site-footer { border-top: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; gap: 30px; padding-block: 36px; }
+.site-footer .brand { font-size: 23px; }
+.site-footer p { font-size: 11px; color: var(--muted); margin: 9px 0 0; }
+.site-footer nav { display: flex; gap: 24px; font-size: 11px; }
+.footer-note { font-family: var(--mono); font-size: 9px; color: var(--muted); }
+
+@media (min-width: 1500px) { .hero { padding-block: 120px; } }
+@media (max-width: 1100px) {
+  .wrap { width: calc(100% - 64px); }
+  .hero { gap: 35px; padding-block: 80px; }
+  .court { right: 5px; transform: rotate(3deg); }
+  h1 { letter-spacing: -4px; }
+  .hero-actions { gap: 18px; flex-wrap: wrap; }
+  .hero-description { font-size: 19px; }
+  .finding-body { padding: 21px 18px; }
+  .window-bar { font-size: 8px; gap: 8px; }
+  .compat-inner { gap: 18px; flex-wrap: wrap; }
+  .compat-inner p span { margin-inline: 6px; }
+  .test-layout { gap: 40px; }
+  .principles { gap: 60px; }
+  .feature-card { padding: 25px; }
+  .install-content { padding-left: 35px; }
+  .footer-note { display: none; }
+}
+@media (max-width: 800px) {
+  .hero { grid-template-columns: 1fr; gap: 70px; padding-block: 65px 50px; }
+  h1 { font-size: clamp(60px, 10vw, 86px); }
+  .hero-copy { max-width: 590px; }
+  .hero-description br { display: none; }
+  .hero-detail { max-width: 480px; }
+  .hero-visual { width: min(100%, 510px); margin-inline: auto; }
+  .finding-body { padding: 25px; }
+  .query-code { font-size: 13px; }
+  .compat-inner { justify-content: center; text-align: center; gap: 12px; }
+  .compat-inner .eyebrow { width: 100%; justify-content: center; }
+  .compat-inner a { margin-left: 0; }
+  .section { padding-block: 70px; }
+  .section-heading { align-items: flex-start; flex-direction: column; gap: 10px; }
+  .section-heading > p { max-width: 470px; }
+  .feature-grid { grid-template-columns: 1fr; }
+  .feature-card { padding: 30px; }
+  .feature-card + .feature-card { border-left: 0; border-top: 1px solid var(--line); }
+  .feature-top { margin-bottom: 20px; }
+  .feature-card p { max-width: 520px; margin-bottom: 18px; }
+  .test-layout { grid-template-columns: 1fr; gap: 35px; }
+  .test-copy > p:not(.eyebrow) { max-width: 450px; }
+  .test-code pre { font-size: 13px; }
+  .principles { grid-template-columns: 1fr; gap: 40px; }
+  .principles-intro > p:not(.eyebrow) { max-width: 460px; }
+  .install-section { grid-template-columns: 1fr; }
+  .install-content { padding: 40px; }
+  .install-content h2 { font-size: 43px; }
+  .install-content > p:not(.eyebrow, .copy-status) { max-width: 440px; }
+  .install-art { display: none; }
+  .faq { grid-template-columns: 1fr; padding-block: 70px; gap: 30px; }
+}
+@media (max-width: 480px) {
+  .wrap { width: calc(100% - 40px); }
+  .site-header { height: 85px; }
+  .brand { font-size: 24px; }
+  .brand img { width: 29px; height: 29px; }
+  .site-header nav { gap: 17px; font-size: 12px; }
+  .site-header nav > a:first-child { display: none; }
+  .nav-github { border: 0; padding: 0; }
+  .nav-github span { padding-left: 3px; }
+  .hero { padding-top: 48px; gap: 55px; }
+  h1 { font-size: 61px; letter-spacing: -3.8px; }
+  .eyebrow { font-size: 9px; }
+  .hero-description { font-size: 18px; }
+  .hero-detail { font-size: 14px; }
+  .hero-actions { gap: 22px; }
+  .button { padding: 16px 18px; font-size: 12px; gap: 20px; }
+  .hero-note { font-size: 9px; }
+  .court { right: 0; left: 17px; transform: rotate(3deg); }
+  .finding-window { transform: none; }
+  .finding-body { padding: 20px 17px; }
+  .window-bar { padding-inline: 12px; }
+  .window-dots { gap: 3px; }
+  .window-dots i { width: 5px; height: 5px; }
+  .query-code { font-size: 10px; padding: 14px 10px; }
+  .finding-label { font-size: 7px; letter-spacing: .3px; }
+  .origin code { font-size: 9px; }
+  .visual-caption { font-size: 10px; }
+  .compat-inner p { font-size: 10px; line-height: 2; }
+  .compat-inner p span { margin-inline: 4px; }
+  h2 { font-size: 36px; letter-spacing: -1.6px; }
+  .test-section { padding-block: 60px; }
+  .test-code pre { padding: 20px 14px; font-size: 10px; }
+  .code-title, .code-footnote { padding-inline: 14px; font-size: 9px; }
+  .install-content { padding: 30px 22px; }
+  .install-content h2 { font-size: 32px; }
+  .install-code pre { font-size: 11px; padding-inline: 13px; }
+  .install-notes { gap: 14px; }
+  .install-notes strong { font-size: 9px; }
+  .faq summary { font-size: 13px; }
+  .site-footer { align-items: flex-start; flex-direction: column; gap: 24px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition: none !important; animation: none !important; }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#f4f2eb">
+  <meta name="description" content="Catch repeated ActiveRecord queries before they become a habit. AndOne brings N+1 investigation, measured query costs, and regression tests to Rails. No external service required.">
+  <meta property="og:title" content="AndOne — Make every query count.">
+  <meta property="og:description" content="Repeated-query detection for Rails. Useful suggestions, measured impact, and a tighter defense in your test suite.">
+  <meta property="og:type" content="website">
+  <title>AndOne — Make every query count.</title>
+  <link rel="icon" href="./assets/icon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="./assets/style.css">
+  <script src="./assets/site.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header wrap">
+    <a class="brand" href="./" aria-label="AndOne home"><img src="./assets/icon.svg" width="34" height="34" alt="">AndOne<span class="brand-dot">.</span></a>
+    <nav aria-label="Main navigation">
+      <a href="#game-plan">How it works</a>
+      <a href="https://github.com/keiththomps/and_one#readme">Docs</a>
+      <a class="nav-github" href="https://github.com/keiththomps/and_one">GitHub <span aria-hidden="true">↗</span></a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero wrap" aria-labelledby="hero-title">
+      <div class="hero-copy">
+        <p class="eyebrow"><span class="status-dot" aria-hidden="true"></span> Open source. Built for Rails.</p>
+        <h1 id="hero-title">Make every<br>query <span class="accent-word">count<svg viewBox="0 0 370 25" aria-hidden="true"><path d="M5 17 Q170 -2 360 10 M40 24 Q200 7 325 18"/></svg></span>.</h1>
+        <p class="hero-description">Your app has enough going on.<br>Repeated queries shouldn’t be part of the game.</p>
+        <p class="hero-detail">AndOne spots repeated ActiveRecord reads, shows their measured cost, and helps you investigate the fix. Right where you work.</p>
+        <div class="hero-actions">
+          <a class="button button-primary" href="#install">Add to your lineup <span aria-hidden="true">↗</span></a>
+          <a class="text-link" href="#game-plan">See the game plan <span aria-hidden="true">↓</span></a>
+        </div>
+        <p class="hero-note">One gem. No external service. MIT licensed.</p>
+      </div>
+
+      <div class="hero-visual">
+        <div class="court" aria-hidden="true"><div class="court-circle"></div><div class="court-key"></div></div>
+        <div class="finding-window">
+          <div class="window-bar"><span class="window-dots" aria-hidden="true"><i></i><i></i><i></i></span><span>development / example finding</span><span class="live-label">LIVE</span></div>
+          <div class="finding-body">
+            <div class="finding-heading"><img src="./assets/icon.svg" width="36" height="36" alt=""><div><strong>And One!</strong><span>1 repeated-query finding</span></div><span class="finding-count">9×</span></div>
+            <div class="finding-label">SUSPECTED ASSOCIATION N+1 <span>CANDIDATE</span></div>
+            <pre class="query-code"><code><span class="syntax-purple">SELECT</span> <span class="syntax-yellow">"comments"</span>.*
+<span class="syntax-purple">FROM</span> <span class="syntax-yellow">"comments"</span>
+<span class="syntax-purple">WHERE</span> <span class="syntax-yellow">"comments"."post_id"</span> = <span class="syntax-orange">?</span></code></pre>
+            <div class="query-metrics"><div><strong>9</strong><span>executed reads</span></div><div><strong>12.4<span>ms</span></strong><span>observed SQL time</span></div></div>
+            <div class="origin"><span>TRIGGERED AT</span><code>app/views/posts/index.html.erb:5</code></div>
+            <div class="suggestion"><span class="suggestion-arrow" aria-hidden="true">↳</span><p>If this is <code>Post#comments</code> record loading, try <code>.preload(:comments)</code> on the parent query. Verify scopes and results.</p></div>
+          </div>
+          <div class="window-footer"><span class="status-dot" aria-hidden="true"></span> SQL samples redacted by default</div>
+        </div>
+        <div class="visual-caption"><span aria-hidden="true">↖</span> Less guesswork. A better next move.</div>
+      </div>
+    </section>
+
+    <div class="compat-strip"><div class="wrap compat-inner"><span class="eyebrow">Plays on your court</span><p>Rails 7+ <span>/</span> Ruby 3.2+ <span>/</span> ActiveJob & Sidekiq <span>/</span> Minitest & RSpec</p><a href="https://github.com/keiththomps/and_one/blob/main/docs/compatibility.md">Tested combinations <span aria-hidden="true">↗</span></a></div></div>
+
+    <section class="section wrap" id="game-plan" aria-labelledby="plan-title">
+      <div class="section-heading"><div><p class="eyebrow">01 / The game plan</p><h2 id="plan-title">Find the repeat.<br>Make the right play.</h2></div><p>No separate service to run. No dashboard account to create. Just feedback in your Rails development loop.</p></div>
+      <div class="feature-grid">
+        <article class="feature-card"><div class="feature-top"><span class="step">01</span><svg viewBox="0 0 48 48" aria-hidden="true"><path d="M9 13h30M9 24h30M9 35h19"/><circle cx="35" cy="35" r="7"/><path d="m40 40 5 5"/></svg></div><h3>Catch the pattern.</h3><p>Automatic request and job scans group repeated reads by SQL shape and call stack. Development notices bring findings to the page you’re already on.</p><span class="feature-tag">In your existing workflow</span></article>
+        <article class="feature-card"><div class="feature-top"><span class="step">02</span><svg viewBox="0 0 48 48" aria-hidden="true"><path d="M8 40V26h7v14M21 40V17h7v23M34 40V7h7v33M5 40h39"/></svg></div><h3>See what matters.</h3><p>Rank findings by observed SQL time, occurrences, or executed query count in the local dashboard. Investigate measured work—not invented savings.</p><span class="feature-tag">Evidence over estimates</span></article>
+        <article class="feature-card"><div class="feature-top"><span class="step">03</span><svg viewBox="0 0 48 48" aria-hidden="true"><path d="m24 5 16 6v13c0 10-16 19-16 19S8 34 8 24V11Z"/><path d="m16 24 6 6 11-13"/></svg></div><h3>Keep it from returning.</h3><p>Fail tests on repeated-query findings. Add explicit query budgets and input-growth assertions to protect the behavior you actually care about.</p><span class="feature-tag">A stronger test defense</span></article>
+      </div>
+    </section>
+
+    <section class="test-section" aria-labelledby="test-title"><div class="wrap test-layout">
+      <div class="test-copy"><p class="eyebrow">02 / Play defense</p><h2 id="test-title">Ship the feature.<br>Not the extra queries.</h2><p>Go beyond “it returns the right records.” Check the database work it takes to get them.</p><ul class="check-list"><li>Repeated-query matchers for Minitest and RSpec</li><li>Inclusive budgets for executed SQL notifications</li><li>Growth checks as your input size increases</li></ul><a class="text-link" href="https://github.com/keiththomps/and_one/blob/main/docs/usage.md#test-matchers">Explore the test helpers <span aria-hidden="true">↗</span></a></div>
+      <div class="test-code"><div class="code-title"><span class="file-icon" aria-hidden="true">◇</span> spec/models/post_spec.rb <span>RSpec</span></div><pre><code><span class="syntax-muted">require</span> <span class="syntax-yellow">"and_one/rspec"</span>
+
+RSpec.describe Post <span class="syntax-purple">do</span>
+  it <span class="syntax-yellow">"loads comments without repeated reads"</span> <span class="syntax-purple">do</span>
+    expect {
+      Post.preload(<span class="syntax-orange">:comments</span>).each <span class="syntax-purple">do</span> |post|
+        post.comments.to_a
+      <span class="syntax-purple">end</span>
+    }.not_to cause_n_plus_one
+  <span class="syntax-purple">end</span>
+<span class="syntax-purple">end</span></code></pre><div class="code-footnote"><span aria-hidden="true">↳</span> Prepare representative data before the expectation.</div></div>
+    </div></section>
+
+    <section class="section wrap principles" aria-labelledby="principles-title">
+      <div class="principles-intro"><p class="eyebrow">03 / No overpromising</p><h2 id="principles-title">An honest call.<br>Not a magic fix.</h2><p>SQL can show repetition. It can’t prove which Ruby association you meant to load. AndOne keeps that distinction visible.</p><a class="text-link" href="https://github.com/keiththomps/and_one#finding-classification">Understand finding kinds <span aria-hidden="true">↗</span></a></div>
+      <div class="principle-list"><article><span aria-hidden="true">↗</span><div><h3>Suggestions, with context.</h3><p>Candidate preloads for basic record loading. Separate guidance for counts, existence checks, and duplicate reads. A caller hint to inspect—not a guaranteed fix location.</p></div></article><article><span aria-hidden="true">◈</span><div><h3>Less data retained.</h3><p>SQL literals are redacted before samples are retained. Bind values are never stored. Samples and aggregate history are bounded. Identifiers may remain visible, so findings are not anonymous.</p></div></article><article><span aria-hidden="true">⌁</span><div><h3>Clear boundaries.</h3><p>Scans cover synchronous ActiveRecord SQL in the current fiber. Async work and lazy response-body queries are outside automatic coverage. All finding kinds can trigger test enforcement.</p></div></article></div>
+    </section>
+
+    <section class="install-section wrap" id="install" aria-labelledby="install-title">
+      <div class="install-content"><p class="eyebrow">04 / Check in</p><h2 id="install-title">Your next good move<br>is one gem away.</h2><p>Add AndOne to development and test, run <code>bundle install</code>, then restart your app. Rails takes care of the hooks.</p><div class="install-code"><div class="install-code-header"><span>Gemfile</span><button type="button" class="copy-button" data-copy="gemfile" hidden>Copy snippet <span aria-hidden="true">⧉</span></button></div><pre><code id="gemfile">group :development, :test do
+  gem "and_one"
+end</code></pre></div><p class="copy-status" role="status" aria-live="polite"></p><div class="install-notes"><span><strong>Development</strong> notices + logs</span><span><strong>Test</strong> raises on findings</span><span><strong>Production</strong> disabled by default</span></div><a class="button button-dark" href="https://github.com/keiththomps/and_one#readme">Read the documentation <span aria-hidden="true">↗</span></a></div>
+      <div class="install-art" aria-hidden="true"><div class="large-ball"><div></div></div><span>AND<br>ONE.</span><p>THE EXTRA POINT IS THE POINT.</p></div>
+    </section>
+
+    <section class="faq wrap" aria-labelledby="faq-title"><div><p class="eyebrow">Before tip-off</p><h2 id="faq-title">Good questions.</h2></div><div class="faq-list">
+      <details><summary>Will every finding be an N+1?<span aria-hidden="true">+</span></summary><p>No. Findings distinguish suspected association N+1s, identical reads, repeated aggregates, and generic repetition. Deliberate batching can also trigger findings. Review the evidence, verify suggestions, and use ignore rules for accepted patterns.</p></details>
+      <details><summary>Do I need another service or account?<span aria-hidden="true">+</span></summary><p>No. AndOne runs in your application. Aggregate findings live in bounded process-local memory by default; opt-in file storage shares them across cooperating processes. Rails development/test also writes a session-scoped logfile by default.</p></details>
+      <details><summary>Can my whole team use the dashboard?<span aria-hidden="true">+</span></summary><p>The development dashboard at <code>/__and_one</code> allows direct loopback peers by default. For shared development, use trusted authentication with an explicit access guard. A local proxy can make remote clients appear local; secure it rather than assuming redaction is enough. <a href="https://github.com/keiththomps/and_one/blob/main/docs/usage.md#capture-privacy-and-dashboard-access">Read the access guidance.</a></p></details>
+      <details><summary>Which versions and databases are supported?<span aria-hidden="true">+</span></summary><p>Ruby 3.2+ and ActiveRecord, ActiveSupport, and Railties 7.0+, in compatible combinations. CI exercises selected Ruby/Rails versions with SQLite, PostgreSQL, and MySQL. Standalone ActiveRecord scripts can scan explicitly; other ORMs are not supported. <a href="https://github.com/keiththomps/and_one/blob/main/docs/compatibility.md">See the tested matrix.</a></p></details>
+    </div></section>
+  </main>
+
+  <footer class="site-footer wrap"><div><a class="brand" href="./"><img src="./assets/icon.svg" width="28" height="28" alt="">AndOne<span class="brand-dot">.</span></a><p>Better queries. Better game.</p></div><nav aria-label="Footer navigation"><a href="https://github.com/keiththomps/and_one">Source <span aria-hidden="true">↗</span></a><a href="https://github.com/keiththomps/and_one#readme">Documentation</a><a href="https://github.com/keiththomps/and_one/blob/main/LICENSE.txt">MIT license</a></nav><span class="footer-note">Made for the Rails community.</span></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a responsive, basketball-inspired marketing site with product examples, test-helper guidance, FAQs, and a copyable installation snippet.
- Keep the site dependency-free, with local assets, progressive enhancement, and reduced-motion support.
- Add a GitHub Actions workflow to publish `site/` to GitHub Pages on changes merged into `main`, plus local preview/deployment instructions.
- Shorten the README, preserve detailed guidance in `docs/usage.md`, and correct stale capture, storage, toast-position, and finding-classification claims.

## Validation
- Chromium checks at 320, 390, 768, 1024, and 1440px: no page overflow; project-prefix asset loading and internal links work.
- Verified clipboard success/manual fallback, FAQ disclosures, reduced motion, and no-JavaScript behavior.
- Automated axe WCAG A/AA checks passed at mobile and desktop sizes.
- JavaScript syntax, workflow YAML parsing, documentation link targets, and `git diff --check` passed.
- Ruby suite not run: no Ruby implementation changes.

## Deployment
Select **Settings → Pages → Build and deployment → GitHub Actions** before deployment. After merging, the workflow publishes to https://keiththomps.github.io/and_one/. This PR does not change repository Pages settings.